### PR TITLE
Add: jdenticon to dependencies

### DIFF
--- a/packages/avatars-jdenticon-sprites/package.json
+++ b/packages/avatars-jdenticon-sprites/package.json
@@ -36,6 +36,9 @@
     "jdenticon": "^2.1.1",
     "typescript": "^3.1.3"
   },
+  "dependencies": {
+    "jdenticon": "^2.1.1"
+  },
   "files": [
     "LICENSE",
     "lib"


### PR DESCRIPTION
fix error:
ERROR in ./node_modules/@dicebear/avatars-jdenticon-sprites/lib/index.js
Module not found: Error: Can't resolve 'jdenticon' in 'D:\Dev\prex-front\node_modules\@dicebear\avatars-jdenticon-sprites\lib'
 @ ./node_modules/@dicebear/avatars-jdenticon-sprites/lib/index.js 7:36-56