### PR TITLE
Make gridy avatars deterministic

### DIFF
--- a/packages/avatars-gridy-sprites/README.md
+++ b/packages/avatars-gridy-sprites/README.md
@@ -16,7 +16,6 @@ Designed by [Jan Forst](https://github.com/darosh/gridy-avatars).
     <img src="https://avatars.dicebear.com/v2/gridy/8.svg" width="60" />
     <img src="https://avatars.dicebear.com/v2/gridy/9.svg" width="60" />
 </p>
-
 ## Usage
 
 ### HTTP-API (recommended)
@@ -64,6 +63,7 @@ let svg = avatars.create('custom-seed');
 | background | string  | `null`                       | Any valid color identifier<br> **HTTP-API limitation** Only hex _(3-digit, 6-digit and 8-digit)_ values are allowed. Use url encoded hash: `%23`. |
 | userAgent  | string  | `window.navigator.userAgent` | User-Agent for legacy browser fallback<br> **Automatically detected by the HTTP API**                                                             |
 | colorful   | boolean | `false`                      | Use different colors for eyes and mouth                                                                                                           |
+| deterministic | boolean | `false`                   | Force deterministic output (see [#64](https://github.com/DiceBear/avatars/issues/64))
 
 ## Further information
 

--- a/packages/avatars-gridy-sprites/package.json
+++ b/packages/avatars-gridy-sprites/package.json
@@ -5,10 +5,11 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
+    "pretest": "npm run build",
+    "test": "jest",
     "prepublishOnly": "npm run build",
     "prebuild": "rm -rf lib/ || true",
-    "build": "tsc",
-    "test": "echo 'No tests available'"
+    "build": "tsc"
   },
   "repository": {
     "type": "git",
@@ -34,6 +35,7 @@
   },
   "devDependencies": {
     "@dicebear/avatars": "^4.0.8",
+    "jest": "^24.8.0",
     "typescript": "^3.4.5"
   },
   "dependencies": {

--- a/packages/avatars-gridy-sprites/src/index.ts
+++ b/packages/avatars-gridy-sprites/src/index.ts
@@ -4,9 +4,23 @@ import Random from '@dicebear/avatars/lib/random';
 
 type Options = {
   colorful?: boolean;
+  deterministic?: boolean;
 };
 
-export default function(random: Random, options: Options = {}) {
+// See https://github.com/DiceBear/avatars/issues/64
+let fixDeterministicClipARegExp = /clipPath id="clip-a-([0-9]*)"/;
+let fixDeterministic = (svg: string, id: number): string => {
+  let match = svg.match(fixDeterministicClipARegExp);
+  if (!match) {
+    return svg;
+  }
+  let [, prevId] = match;
+  let clipA = new RegExp(`clip-a-${prevId}`, "g");
+  let clipB = new RegExp(`clip-b-${prevId}`, "g");
+  return svg.replace(clipA, `clip-a-${id}`).replace(clipB, `clip-b-${id}`);
+};
+
+export default function (random: Random, options: Options = {}) {
   let body = random.integer(0, 7);
   let bodyColor = random.integer(0, 7);
 
@@ -16,9 +30,17 @@ export default function(random: Random, options: Options = {}) {
   let mouth = random.integer(0, 7);
   let mouthColor = options.colorful ? random.integer(0, 7) : eyesColor;
 
+  let deterministic = options && options.deterministic;
+
+  let svg = inner(`${body}${bodyColor}${eyes}${eyesColor}${mouth}${mouthColor}`);
+  if (deterministic) {
+    let id = random.integer(0, 10e9);
+    svg = fixDeterministic(svg, id);
+  }
+
   return [
     '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="isolation:isolate" viewBox="0 0 24 24" version="1.1">',
-    inner(`${body}${bodyColor}${eyes}${eyesColor}${mouth}${mouthColor}`),
+    svg,
     '</svg>'
   ].join('');
 }

--- a/packages/avatars-gridy-sprites/tests/deterministic.test.js
+++ b/packages/avatars-gridy-sprites/tests/deterministic.test.js
@@ -1,0 +1,9 @@
+const create = require("../lib/index").default;
+const Random = require("@dicebear/avatars/lib/random").default;
+
+test('Deterministic create', () => {
+  let svg1 = create(new Random("arbitrary seed"), { deterministic: true });
+  let svg2 = create(new Random("arbitrary seed"), { deterministic: true });
+
+  expect(svg2).toEqual(svg1);
+});


### PR DESCRIPTION
- Add options.deterministic to gridy avatars
  If enabled, this option replaces the stateful output of gridy-avatars
    with a deterministic version by monkey-patching the output.

- Add jest + test to gridy avatars
  Check that the output is indeed deterministic when using the above
    option.