### PR TITLE
Remove Redundant Word from Documentation

### DIFF
--- a/website/pages/how-to-use/http-api/index.md
+++ b/website/pages/how-to-use/http-api/index.md
@@ -92,7 +92,7 @@ Supported versions: `5.x`, `6.x`, `7.x`
 ::: warning
 
 We reserve the right to discontinue any version at any time without notice. You
-can create your own own instance of the API to be able to access discontinued
+can create your own instance of the API to be able to access discontinued
 versions even afterwards.
 
 :::


### PR DESCRIPTION
Removed the redundant word "own" from the warning message in the documentation.

![image](https://github.com/dicebear/dicebear/assets/22786810/6fc7edfb-f633-4bac-8602-2a5a995478ec)
