### PR TITLE
Should list the usage guides for different frameworks

### DIFF
--- a/apps/docs/pages/how-to-use/js-library/index.md
+++ b/apps/docs/pages/how-to-use/js-library/index.md
@@ -55,6 +55,13 @@ const avatar = createAvatar(lorelei, {
 const svg = avatar.toString();
 ```
 
+See usage guides for different frameworks:
+
+- [How to use the library with React?](/guides/use-the-library-with-react/)
+- [How to use the library with React Native?](/guides/use-the-library-with-react-native/)
+- [How to use the library with Svelte?](/guides/use-the-library-with-svelte/)
+- [How to use the library with Vue?](/guides/use-the-library-with-vue/)
+
 Each avatar style comes with several options. You can find them on the details
 page of each [avatar style](/styles/).
 


### PR DESCRIPTION
The links on how to render the avatar for different frameworks should be listed on the `js-library` page for easy access, since those guides are at the very bottom of the sidebar and is not easily noticeable.

Also, I think the library is for those frameworks, so, its kinda bummer not to include theme.