### PR TITLE
Fix PQueue initialization when no CPU information is available

### DIFF
--- a/packages/dicebear/src/utils/addStyleCommand.ts
+++ b/packages/dicebear/src/utils/addStyleCommand.ts
@@ -48,7 +48,7 @@ export function addStyleCommand(
 
       bar.start(count, 0);
 
-      const queue = new PQueue({ concurrency: os.cpus().length });
+      const queue = new PQueue({ concurrency: os.cpus().length || 1 });
 
       queue.on('next', () => {
         bar.update(count - queue.size - queue.pending);


### PR DESCRIPTION
https://nodejs.org/api/os.html#oscpus

May return an empty array, leading to 0 length, which causes a TypeError: Expected `concurrency` to be a number from 1 and up, got `0` (number)