### PR TITLE
Harden PlaygroundCustomStyleUpload against large files and leaky errors

### DIFF
--- a/apps/docs/.vitepress/theme/components/playground/PlaygroundCustomStyleUpload.vue
+++ b/apps/docs/.vitepress/theme/components/playground/PlaygroundCustomStyleUpload.vue
@@ -50,6 +50,12 @@ function extractName(definition: Record<string, unknown>): string {
 
 async function submit() {
   error.value = '';
+
+  if (new TextEncoder().encode(jsonInput.value).length > MAX_UPLOAD_SIZE) {
+    error.value = 'Style definition is too large (max 1 MB).';
+    return;
+  }
+
   loading.value = true;
 
   try {

--- a/apps/docs/.vitepress/theme/components/playground/PlaygroundCustomStyleUpload.vue
+++ b/apps/docs/.vitepress/theme/components/playground/PlaygroundCustomStyleUpload.vue
@@ -17,6 +17,8 @@ const emit = defineEmits<{
 
 const store = useStore();
 
+const MAX_UPLOAD_SIZE = 1024 * 1024;
+
 const jsonInput = ref('');
 const styleName = ref('');
 const error = ref('');
@@ -65,7 +67,7 @@ async function submit() {
     if (err instanceof SyntaxError) {
       error.value = 'Invalid JSON: ' + err.message;
     } else if (err instanceof Error) {
-      error.value = err.message;
+      error.value = 'Invalid style definition. Check format and required fields.';
     } else {
       error.value = 'An unknown error occurred.';
     }
@@ -78,7 +80,15 @@ async function onFileSelect(event: Event) {
   const input = event.target as HTMLInputElement;
   const file = input.files?.[0];
 
+  error.value = '';
+
   if (!file) return;
+
+  if (file.size > MAX_UPLOAD_SIZE) {
+    error.value = 'File is too large (max 1 MB).';
+    input.value = '';
+    return;
+  }
 
   try {
     jsonInput.value = await file.text();


### PR DESCRIPTION
## Summary
- Add a 1 MB upload size limit before reading the file (`onFileSelect`).
- Apply the same 1 MB limit to JSON pasted directly into the textarea (`submit`), measured in UTF-8 bytes via `TextEncoder` so it matches the `File.size` check.
- Reset `error.value` at the start of `onFileSelect` so a stale error from a previous attempt does not persist.
- Replace the leaked `Style` constructor message with a generic "Invalid style definition. Check format and required fields." for non-JSON errors. JSON syntax errors keep their specific message.

## Test plan
- [x] `npx vitepress build .` succeeds
- [x] Upload an oversized JSON file → friendly error (verified via `onFileSelect` size check)
- [x] Paste an oversized JSON definition into the textarea → friendly error (verified via `submit()` byte-length check)
- [x] Upload an invalid style definition → generic error, no constructor internals leaked (verified via `submit()` catch branch)
- [x] Upload valid JSON → style is added (verified via `submit()` happy path)