### PR TITLE
Validate external style-metadata URLs across docs

### DIFF
--- a/apps/docs/.vitepress/theme/components/app/AppSeedDemo.vue
+++ b/apps/docs/.vitepress/theme/components/app/AppSeedDemo.vue
@@ -6,6 +6,7 @@ import { UiAvatar, UiHeadline, UiDescription, UiBadge, UiContainer, UiSection, U
 import { useVisibility } from '../../composables/useVisibility';
 import { useAvatarStyleList, useAvatarStyleMeta } from '../../composables/avatar';
 import { formatLicenseName } from '../../utils/format';
+import { safeHttpUrl } from '../../utils/url';
 import AppSeedDemoCode from './AppSeedDemoCode.vue';
 import AppSeedDemoStylePicker from './AppSeedDemoStylePicker.vue';
 
@@ -49,6 +50,10 @@ function onSeedInput(event: Event) {
 const mainAvatarLink = computed(() =>
   `https://api.dicebear.com/10.x/${currentStyle.value}/svg?seed=${encodeURIComponent(seed.value)}`
 );
+
+const sourceUrl = computed(() => safeHttpUrl(avatarStyleMeta.value?.source));
+const homepageUrl = computed(() => safeHttpUrl(avatarStyleMeta.value?.homepage));
+const licenseUrl = computed(() => safeHttpUrl(avatarStyleMeta.value?.license?.url));
 
 const allStyleAvatars = computed(() =>
   avatarStyleList.value.map((style, index) => ({
@@ -150,11 +155,14 @@ function selectStyle(index: number) {
               is a remix of
             </template>
             <template v-else> is based on </template>
-            <a :href="avatarStyleMeta?.source" target="_blank" rel="noopener noreferrer">{{ avatarStyleMeta?.title ?? 'Design' }}</a>
+            <a v-if="sourceUrl" :href="sourceUrl" target="_blank" rel="noopener noreferrer">{{ avatarStyleMeta?.title ?? 'Design' }}</a>
+            <template v-else>{{ avatarStyleMeta?.title ?? 'Design' }}</template>
           </template>
           by
-          <a :href="avatarStyleMeta?.homepage" target="_blank" rel="noopener noreferrer">{{ avatarStyleMeta?.creator }}</a>, licensed under
-          <a :href="avatarStyleMeta?.license?.url" target="_blank" rel="noopener noreferrer">{{ formatLicenseName(avatarStyleMeta?.license?.name) }}</a>.
+          <a v-if="homepageUrl" :href="homepageUrl" target="_blank" rel="noopener noreferrer">{{ avatarStyleMeta?.creator }}</a>
+          <template v-else>{{ avatarStyleMeta?.creator }}</template>, licensed under
+          <a v-if="licenseUrl" :href="licenseUrl" target="_blank" rel="noopener noreferrer">{{ formatLicenseName(avatarStyleMeta?.license?.name) }}</a>
+          <template v-else>{{ formatLicenseName(avatarStyleMeta?.license?.name) }}</template>.
         </p>
       </div>
 

--- a/apps/docs/.vitepress/theme/components/layout/LayoutFooter.vue
+++ b/apps/docs/.vitepress/theme/components/layout/LayoutFooter.vue
@@ -6,6 +6,7 @@ import { siGithub, siFigma } from 'simple-icons';
 import { UiIcon } from '../ui';
 import type { AvatarStyleMeta, ThemeOptions } from '@theme/types';
 import { productLinks as exploreLinks, resourceLinks, legalLinks } from '../../config/footer-links';
+import { safeHttpUrl } from '@theme/utils/url';
 
 const { theme } = useData<ThemeOptions>();
 const { hasSidebar } = useLayout();
@@ -169,13 +170,15 @@ const styles = computed(() => {
         <div class="layout-footer-bottom-inner">
           <p class="layout-footer-attributions">
             <template v-for="(style, index) in styles" :key="style.source">
-              <a class="layout-footer-attribution-link" :href="style.source" target="_blank" rel="noopener">{{
+              <a v-if="safeHttpUrl(style.source)" class="layout-footer-attribution-link" :href="safeHttpUrl(style.source)" target="_blank" rel="noopener">{{
                 style.title
               }}</a>
+              <template v-else>{{ style.title }}</template>
               by {{ style.creator }} /
-              <a class="layout-footer-attribution-link" :href="style.license?.url" target="_blank" rel="noopener">{{
+              <a v-if="safeHttpUrl(style.license?.url)" class="layout-footer-attribution-link" :href="safeHttpUrl(style.license?.url)" target="_blank" rel="noopener">{{
                 style.license?.name
-              }}</a><template v-if="index < styles.length - 1">. </template>
+              }}</a>
+              <template v-else>{{ style.license?.name }}</template><template v-if="index < styles.length - 1">. </template>
             </template>
             — All avatars are remixes of the original works.
           </p>

--- a/apps/docs/.vitepress/theme/components/pages/PageLicenses.vue
+++ b/apps/docs/.vitepress/theme/components/pages/PageLicenses.vue
@@ -2,6 +2,7 @@
 import { useData } from 'vitepress';
 import { ThemeOptions } from '@theme/types';
 import { kebabCase } from 'change-case';
+import { safeHttpUrl } from '@theme/utils/url';
 
 const { theme } = useData<ThemeOptions>();
 const styles = theme.value.avatarStyles;
@@ -34,13 +35,15 @@ const styles = theme.value.avatarStyles;
       <tr v-if="style.meta.source">
         <td>Source</td>
         <td>
-          <a :href="style.meta.source" target="_blank" rel="noopener noreferrer">{{ style.meta.source }}</a>
+          <a v-if="safeHttpUrl(style.meta.source)" :href="safeHttpUrl(style.meta.source)" target="_blank" rel="noopener noreferrer">{{ style.meta.source }}</a>
+          <template v-else>{{ style.meta.source }}</template>
         </td>
       </tr>
       <tr v-if="style.meta.homepage">
         <td>Homepage</td>
         <td>
-          <a :href="style.meta.homepage" target="_blank" rel="noopener noreferrer">{{ style.meta.homepage }}</a>
+          <a v-if="safeHttpUrl(style.meta.homepage)" :href="safeHttpUrl(style.meta.homepage)" target="_blank" rel="noopener noreferrer">{{ style.meta.homepage }}</a>
+          <template v-else>{{ style.meta.homepage }}</template>
         </td>
       </tr>
       <tr v-if="style.meta.license?.name">
@@ -50,9 +53,10 @@ const styles = theme.value.avatarStyles;
       <tr v-if="style.meta.license?.url">
         <td>License URL</td>
         <td>
-          <a :href="style.meta.license?.url" target="_blank" rel="noopener noreferrer">{{
+          <a v-if="safeHttpUrl(style.meta.license?.url)" :href="safeHttpUrl(style.meta.license?.url)" target="_blank" rel="noopener noreferrer">{{
             style.meta.license?.url
           }}</a>
+          <template v-else>{{ style.meta.license?.url }}</template>
         </td>
       </tr>
     </tbody>

--- a/apps/docs/.vitepress/theme/components/playground/PlaygroundLicenseText.vue
+++ b/apps/docs/.vitepress/theme/components/playground/PlaygroundLicenseText.vue
@@ -6,16 +6,7 @@ import { computed, toRef } from 'vue';
 import { computedAsync } from '@vueuse/core';
 import useStore from '@theme/stores/playground';
 import { formatLicenseName } from '@theme/utils/format';
-
-function safeHttpUrl(url: string | undefined | null): string | undefined {
-  if (!url) return undefined;
-  try {
-    const u = new URL(url);
-    return u.protocol === 'http:' || u.protocol === 'https:' ? url : undefined;
-  } catch {
-    return undefined;
-  }
-}
+import { safeHttpUrl } from '@theme/utils/url';
 
 const store = useStore();
 
@@ -51,6 +42,10 @@ const hasCustomMeta = computed(() => {
 
 const customSourceUrl = computed(() => safeHttpUrl(customStyleMeta.value?.source));
 const customLicenseUrl = computed(() => safeHttpUrl(customStyleMeta.value?.license?.url));
+
+const builtInSourceUrl = computed(() => safeHttpUrl(avatarStyleMeta.value?.source));
+const builtInHomepageUrl = computed(() => safeHttpUrl(avatarStyleMeta.value?.homepage));
+const builtInLicenseUrl = computed(() => safeHttpUrl(avatarStyleMeta.value?.license?.url));
 
 const avatarStyleName = computed(() => {
   if (store.isCustomStyle) {
@@ -116,28 +111,32 @@ const avatarStyleLink = computed(
       </template>
       <template v-else> is based on: </template>
       <a
-        :href="avatarStyleMeta?.source"
+        v-if="builtInSourceUrl"
+        :href="builtInSourceUrl"
         target="_blank"
         rel="noopener noreferrer"
       >
         {{ avatarStyleMeta?.title ?? 'Design' }}
       </a>
+      <template v-else>{{ avatarStyleMeta?.title ?? 'Design' }}</template>
     </template>
     by
     <a
-      :href="avatarStyleMeta?.homepage"
+      v-if="builtInHomepageUrl"
+      :href="builtInHomepageUrl"
       target="_blank"
       rel="noopener noreferrer"
-    >
-      {{ avatarStyleMeta?.creator }} </a
-    >, licensed under
+    >{{ avatarStyleMeta?.creator }}</a>
+    <template v-else>{{ avatarStyleMeta?.creator }}</template>, licensed under
     <a
-      :href="avatarStyleMeta?.license?.url"
+      v-if="builtInLicenseUrl"
+      :href="builtInLicenseUrl"
       target="_blank"
       rel="noopener noreferrer"
     >
       {{ formatLicenseName(avatarStyleMeta?.license?.name) }}
     </a>
+    <template v-else>{{ formatLicenseName(avatarStyleMeta?.license?.name) }}</template>
     .
   </p>
 </template>

--- a/apps/docs/.vitepress/theme/components/playground/PlaygroundLicenseText.vue
+++ b/apps/docs/.vitepress/theme/components/playground/PlaygroundLicenseText.vue
@@ -7,6 +7,16 @@ import { computedAsync } from '@vueuse/core';
 import useStore from '@theme/stores/playground';
 import { formatLicenseName } from '@theme/utils/format';
 
+function safeHttpUrl(url: string | undefined | null): string | undefined {
+  if (!url) return undefined;
+  try {
+    const u = new URL(url);
+    return u.protocol === 'http:' || u.protocol === 'https:' ? url : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 const store = useStore();
 
 const avatarStyleMeta = useAvatarStyleMeta(toRef(store, 'avatarStyleName'));
@@ -39,6 +49,9 @@ const hasCustomMeta = computed(() => {
   return meta && (meta.creator || meta.license?.name);
 });
 
+const customSourceUrl = computed(() => safeHttpUrl(customStyleMeta.value?.source));
+const customLicenseUrl = computed(() => safeHttpUrl(customStyleMeta.value?.license?.url));
+
 const avatarStyleName = computed(() => {
   if (store.isCustomStyle) {
     return store.customStyles[store.avatarStyleName]?.name ?? 'Custom Style';
@@ -59,12 +72,12 @@ const avatarStyleLink = computed(
       <template v-if="customStyleMeta?.title">
         is based on:
         <a
-          v-if="customStyleMeta?.source"
-          :href="customStyleMeta.source"
+          v-if="customSourceUrl"
+          :href="customSourceUrl"
           target="_blank"
           rel="noopener noreferrer"
-        >{{ customStyleMeta.title }}</a>
-        <template v-else>{{ customStyleMeta.title }}</template>
+        >{{ customStyleMeta?.title }}</a>
+        <template v-else>{{ customStyleMeta?.title }}</template>
       </template>
       <template v-if="customStyleMeta?.creator">
         by {{ customStyleMeta.creator }}
@@ -72,12 +85,12 @@ const avatarStyleLink = computed(
       <template v-if="customStyleMeta?.license?.name">
         , licensed under
         <a
-          v-if="customStyleMeta?.license?.url"
-          :href="customStyleMeta.license.url"
+          v-if="customLicenseUrl"
+          :href="customLicenseUrl"
           target="_blank"
           rel="noopener noreferrer"
-        >{{ customStyleMeta.license.name }}</a>
-        <template v-else>{{ customStyleMeta.license.name }}</template>
+        >{{ customStyleMeta?.license?.name }}</a>
+        <template v-else>{{ customStyleMeta?.license?.name }}</template>
       </template>
       (as stated by the creator — not verified by DiceBear).
     </template>

--- a/apps/docs/.vitepress/theme/components/styles/StyleDescription.vue
+++ b/apps/docs/.vitepress/theme/components/styles/StyleDescription.vue
@@ -4,6 +4,7 @@ import { useData } from 'vitepress';
 import { ThemeOptions } from '@theme/types';
 import { kebabCase } from 'change-case';
 import { formatLicenseName } from '@theme/utils/format';
+import { safeHttpUrl } from '@theme/utils/url';
 
 const { theme } = useData<ThemeOptions>();
 const props = defineProps<{
@@ -17,6 +18,10 @@ const style = computed(() => {
 const playgroundUrl = computed(() => {
   return `/playground?style=${kebabCase(props.styleName)}`;
 });
+
+const sourceUrl = computed(() => safeHttpUrl(style.value.meta?.source));
+const homepageUrl = computed(() => safeHttpUrl(style.value.meta?.homepage));
+const licenseUrl = computed(() => safeHttpUrl(style.value.meta?.license?.url));
 </script>
 
 <template>
@@ -27,20 +32,22 @@ const playgroundUrl = computed(() => {
       </template>
       <template v-else> This avatar style is based on: </template>
     </template>
-    <a :href="style.meta?.source" target="_blank" rel="noopener noreferrer">
+    <a v-if="sourceUrl" :href="sourceUrl" target="_blank" rel="noopener noreferrer">
       {{ style.meta?.title ?? 'Design' }}
     </a>
+    <template v-else>{{ style.meta?.title ?? 'Design' }}</template>
     by
-    <a :href="style.meta?.homepage" target="_blank" rel="noopener noreferrer">
-      {{ style.meta?.creator }} </a
-    >, licensed under
+    <a v-if="homepageUrl" :href="homepageUrl" target="_blank" rel="noopener noreferrer">{{ style.meta?.creator }}</a>
+    <template v-else>{{ style.meta?.creator }}</template>, licensed under
     <a
-      :href="style.meta?.license?.url"
+      v-if="licenseUrl"
+      :href="licenseUrl"
       target="_blank"
       rel="noopener noreferrer"
     >
       {{ formatLicenseName(style.meta?.license?.name) }}
     </a>
+    <template v-else>{{ formatLicenseName(style.meta?.license?.name) }}</template>
     .
   </p>
 
@@ -50,11 +57,13 @@ const playgroundUrl = computed(() => {
       While our code is MIT licensed, the design of this avatar style is
       licensed under
       <a
-        :href="style.meta.license?.url"
+        v-if="licenseUrl"
+        :href="licenseUrl"
         target="_blank"
         rel="noopener noreferrer"
         >{{ formatLicenseName(style.meta.license?.name) }}</a
-      >. See <a href="#details">details</a> for more information.
+      >
+      <template v-else>{{ formatLicenseName(style.meta.license?.name) }}</template>. See <a href="#details">details</a> for more information.
     </p>
   </div>
 

--- a/apps/docs/.vitepress/theme/components/styles/StyleInfo.vue
+++ b/apps/docs/.vitepress/theme/components/styles/StyleInfo.vue
@@ -4,6 +4,7 @@ import { useData } from 'vitepress';
 import { ThemeOptions } from '@theme/types';
 import { UiCode as Code } from '../ui';
 import { kebabCase } from 'change-case';
+import { safeHttpUrl } from '@theme/utils/url';
 
 const { theme } = useData<ThemeOptions>();
 
@@ -102,8 +103,8 @@ const exampleCliCommand = computed(() => {
         <td>Creator</td>
         <td>
           <a
-            v-if="style.meta.homepage"
-            :href="style.meta.homepage"
+            v-if="safeHttpUrl(style.meta.homepage)"
+            :href="safeHttpUrl(style.meta.homepage)"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -118,19 +119,21 @@ const exampleCliCommand = computed(() => {
         <td>Website</td>
         <td>
           <a
-            :href="style.meta.homepage"
+            v-if="safeHttpUrl(style.meta.homepage)"
+            :href="safeHttpUrl(style.meta.homepage)"
             target="_blank"
             rel="noopener noreferrer"
             >{{ style.meta.homepage }}</a
           >
+          <template v-else>{{ style.meta.homepage }}</template>
         </td>
       </tr>
       <tr v-if="style.meta.license">
         <td>License</td>
         <td>
           <a
-            v-if="style.meta.license.url"
-            :href="style.meta.license.url"
+            v-if="safeHttpUrl(style.meta.license.url)"
+            :href="safeHttpUrl(style.meta.license.url)"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -145,11 +148,13 @@ const exampleCliCommand = computed(() => {
         <td>Source</td>
         <td>
           <a
-            :href="style.meta.source"
+            v-if="safeHttpUrl(style.meta.source)"
+            :href="safeHttpUrl(style.meta.source)"
             target="_blank"
             rel="noopener noreferrer"
             >{{ style.meta.source }}</a
           >
+          <template v-else>{{ style.meta.source }}</template>
         </td>
       </tr>
     </tbody>

--- a/apps/docs/.vitepress/theme/utils/url.ts
+++ b/apps/docs/.vitepress/theme/utils/url.ts
@@ -1,0 +1,15 @@
+/**
+ * Returns the URL only if it parses and uses an http(s) protocol; otherwise
+ * undefined. Use this for any href that ultimately renders user-provided or
+ * style-metadata URLs so that javascript:, data:, file: and other dangerous
+ * schemes are dropped before they reach the DOM.
+ */
+export function safeHttpUrl(url: string | undefined | null): string | undefined {
+  if (!url) return undefined;
+  try {
+    const u = new URL(url);
+    return u.protocol === 'http:' || u.protocol === 'https:' ? url : undefined;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary
Defense-in-depth: every external `<a href>` binding in the docs that ultimately renders a style-metadata URL is now run through a shared `safeHttpUrl` helper. URLs whose protocol is not `http:` or `https:` (including `javascript:`, `data:`, `file:`) are dropped, and the visible text is rendered without the link wrapper instead.

### New
- `apps/docs/.vitepress/theme/utils/url.ts` — exports `safeHttpUrl(url)`, single source of truth.

### Touched
| Component | Bindings hardened |
| --- | --- |
| `playground/PlaygroundLicenseText.vue` | Custom-style `source` / `license.url` **and** built-in `source` / `homepage` / `license.url` |
| `pages/PageLicenses.vue` | Source / Homepage / License URL table rows |
| `styles/StyleInfo.vue` | Creator-via-Homepage / Website / License / Source rows |
| `styles/StyleDescription.vue` | Intro paragraph + LICENSE custom block |
| `app/AppSeedDemo.vue` | License disclaimer (source / homepage / license url) |
| `layout/LayoutFooter.vue` | Per-style attribution links (source + license url) |

### Threat model
Custom styles in the playground are user-uploaded JSON, so URLs in them are fully user-controlled — `"source": "javascript:..."` would otherwise execute on click. Built-in style URLs come from build-time `avatarStyles.ts` config and are not runtime-user-controllable today, but the same templates are reused for custom styles via the playground store and a single review-slip in a definitions JSON would otherwise propagate everywhere. Validating once in a shared helper closes both fronts.

## Test plan
- [x] `npx vitepress build .` succeeds
- [x] Custom style with `javascript:` URL → link is dropped, visible text rendered
- [x] Custom style with `https://` URL → link works
- [x] Built-in style with normal URL → links work in PageLicenses, StyleInfo, StyleDescription, AppSeedDemo, LayoutFooter
- [x] Hypothetical broken/relative/`javascript:` URL in any built-in definition → all six components render plain text instead of a broken `<a>`