### PR TITLE
Extract PlaygroundRangeField to deduplicate slider/range markup

### DIFF
--- a/apps/docs/.vitepress/theme/components/playground/PlaygroundComponentSection.vue
+++ b/apps/docs/.vitepress/theme/components/playground/PlaygroundComponentSection.vue
@@ -2,8 +2,9 @@
 import Slider from 'primevue/slider';
 import Button from 'primevue/button';
 import InputNumber from 'primevue/inputnumber';
-import { ArrowLeftRight, Weight } from '@lucide/vue';
+import { Weight } from '@lucide/vue';
 import { UiAvatar } from '../ui';
+import PlaygroundRangeField from './PlaygroundRangeField.vue';
 import useStore from '@theme/stores/playground';
 import { useRangeField } from '@theme/composables/useRangeField';
 import { useVariantWeights } from '@theme/composables/useVariantWeights';
@@ -55,7 +56,7 @@ function variantPreviewOptions(variant: string) {
   );
 }
 
-const { rangeMode, isRangeMode, toggleRangeMode, singleComputed, rangeComputed } = useRangeField(store.avatarStyleOptions);
+const { singleComputed } = useRangeField(store.avatarStyleOptions);
 
 const probability = singleComputed(`${props.componentName}Probability`, props.defaultProbability);
 
@@ -67,17 +68,9 @@ const defaultRotateFallback = props.defaultRotate.length === 1 ? props.defaultRo
 const defaultTranslateXFallback = props.defaultTranslateX.length === 1 ? props.defaultTranslateX[0] : 0;
 const defaultTranslateYFallback = props.defaultTranslateY.length === 1 ? props.defaultTranslateY[0] : 0;
 
-// Initialize range mode from defaults if they define a range
-if (props.defaultRotate.length === 2) rangeMode[rotateKey] = true;
-if (props.defaultTranslateX.length === 2) rangeMode[translateXKey] = true;
-if (props.defaultTranslateY.length === 2) rangeMode[translateYKey] = true;
-
-const rotateSingle = singleComputed(rotateKey, defaultRotateFallback);
-const rotateRange = rangeComputed(rotateKey, props.defaultRotate.length === 2 ? props.defaultRotate : defaultRotateFallback);
-const translateXSingle = singleComputed(translateXKey, defaultTranslateXFallback);
-const translateXRange = rangeComputed(translateXKey, props.defaultTranslateX.length === 2 ? props.defaultTranslateX : defaultTranslateXFallback);
-const translateYSingle = singleComputed(translateYKey, defaultTranslateYFallback);
-const translateYRange = rangeComputed(translateYKey, props.defaultTranslateY.length === 2 ? props.defaultTranslateY : defaultTranslateYFallback);
+const defaultRotateRange = props.defaultRotate.length === 2 ? props.defaultRotate : undefined;
+const defaultTranslateXRange = props.defaultTranslateX.length === 2 ? props.defaultTranslateX : undefined;
+const defaultTranslateYRange = props.defaultTranslateY.length === 2 ? props.defaultTranslateY : undefined;
 </script>
 
 <template>
@@ -141,62 +134,41 @@ const translateYRange = rangeComputed(translateYKey, props.defaultTranslateY.len
       <Slider v-model="probability" :min="0" :max="100" :step="1" />
     </div>
 
-    <div class="pg-field" v-if="hasRotate">
-      <div class="pg-field-label">
-        <span>Rotate</span>
-        <Button
-          size="small"
-          :severity="isRangeMode(rotateKey) ? 'primary' : 'secondary'"
-          v-tooltip="isRangeMode(rotateKey) ? 'Switch to fixed value' : 'Switch to range'"
-          @click="toggleRangeMode(rotateKey, 0)"
-          class="pg-field-toggle"
-        >
-          <ArrowLeftRight :size="14" />
-        </Button>
-        <span class="pg-field-value" v-if="isRangeMode(rotateKey)">{{ rotateRange[0] }}° — {{ rotateRange[1] }}°</span>
-        <span class="pg-field-value" v-else>{{ rotateSingle }}°</span>
-      </div>
-      <Slider v-if="isRangeMode(rotateKey)" v-model="rotateRange" :range="true" :min="-360" :max="360" :step="1" />
-      <Slider v-else v-model="rotateSingle" :min="-360" :max="360" :step="1" />
-    </div>
+    <PlaygroundRangeField
+      v-if="hasRotate"
+      label="Rotate"
+      :option-key="rotateKey"
+      :min="-360"
+      :max="360"
+      :step="1"
+      unit="°"
+      :default-single="defaultRotateFallback"
+      :default-range="defaultRotateRange"
+    />
 
-    <div class="pg-field" v-if="hasTranslateX">
-      <div class="pg-field-label">
-        <span>Translate X</span>
-        <Button
-          size="small"
-          :severity="isRangeMode(translateXKey) ? 'primary' : 'secondary'"
-          v-tooltip="isRangeMode(translateXKey) ? 'Switch to fixed value' : 'Switch to range'"
-          @click="toggleRangeMode(translateXKey, 0)"
-          class="pg-field-toggle"
-        >
-          <ArrowLeftRight :size="14" />
-        </Button>
-        <span class="pg-field-value" v-if="isRangeMode(translateXKey)">{{ translateXRange[0] }}% — {{ translateXRange[1] }}%</span>
-        <span class="pg-field-value" v-else>{{ translateXSingle }}%</span>
-      </div>
-      <Slider v-if="isRangeMode(translateXKey)" v-model="translateXRange" :range="true" :min="-100" :max="100" :step="1" />
-      <Slider v-else v-model="translateXSingle" :min="-100" :max="100" :step="1" />
-    </div>
+    <PlaygroundRangeField
+      v-if="hasTranslateX"
+      label="Translate X"
+      :option-key="translateXKey"
+      :min="-100"
+      :max="100"
+      :step="1"
+      unit="%"
+      :default-single="defaultTranslateXFallback"
+      :default-range="defaultTranslateXRange"
+    />
 
-    <div class="pg-field" v-if="hasTranslateY">
-      <div class="pg-field-label">
-        <span>Translate Y</span>
-        <Button
-          size="small"
-          :severity="isRangeMode(translateYKey) ? 'primary' : 'secondary'"
-          v-tooltip="isRangeMode(translateYKey) ? 'Switch to fixed value' : 'Switch to range'"
-          @click="toggleRangeMode(translateYKey, 0)"
-          class="pg-field-toggle"
-        >
-          <ArrowLeftRight :size="14" />
-        </Button>
-        <span class="pg-field-value" v-if="isRangeMode(translateYKey)">{{ translateYRange[0] }}% — {{ translateYRange[1] }}%</span>
-        <span class="pg-field-value" v-else>{{ translateYSingle }}%</span>
-      </div>
-      <Slider v-if="isRangeMode(translateYKey)" v-model="translateYRange" :range="true" :min="-100" :max="100" :step="1" />
-      <Slider v-else v-model="translateYSingle" :min="-100" :max="100" :step="1" />
-    </div>
+    <PlaygroundRangeField
+      v-if="hasTranslateY"
+      label="Translate Y"
+      :option-key="translateYKey"
+      :min="-100"
+      :max="100"
+      :step="1"
+      unit="%"
+      :default-single="defaultTranslateYFallback"
+      :default-range="defaultTranslateYRange"
+    />
   </div>
 </template>
 

--- a/apps/docs/.vitepress/theme/components/playground/PlaygroundRangeField.vue
+++ b/apps/docs/.vitepress/theme/components/playground/PlaygroundRangeField.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import Slider from 'primevue/slider';
+import Button from 'primevue/button';
+import { ArrowLeftRight } from '@lucide/vue';
+import useStore from '@theme/stores/playground';
+import { useRangeField } from '@theme/composables/useRangeField';
+
+const props = withDefaults(
+  defineProps<{
+    label: string;
+    optionKey: string;
+    min: number;
+    max: number;
+    step: number;
+    unit?: string;
+    defaultSingle: number;
+    defaultRange?: readonly number[];
+  }>(),
+  {
+    unit: '',
+  },
+);
+
+const store = useStore();
+const { rangeMode, isRangeMode, toggleRangeMode, singleComputed, rangeComputed } = useRangeField(store.avatarStyleOptions);
+
+if (props.defaultRange && props.defaultRange.length === 2) {
+  rangeMode[props.optionKey] = true;
+}
+
+const singleVal = singleComputed(props.optionKey, props.defaultSingle);
+const rangeVal = rangeComputed(props.optionKey, props.defaultRange ?? props.defaultSingle);
+</script>
+
+<template>
+  <div class="pg-field">
+    <div class="pg-field-label">
+      <span>{{ label }}</span>
+      <Button
+        size="small"
+        :severity="isRangeMode(optionKey) ? 'primary' : 'secondary'"
+        v-tooltip="isRangeMode(optionKey) ? 'Switch to fixed value' : 'Switch to range'"
+        @click="toggleRangeMode(optionKey, defaultSingle)"
+        class="pg-field-toggle"
+      >
+        <ArrowLeftRight :size="14" />
+      </Button>
+      <span class="pg-field-value" v-if="isRangeMode(optionKey)">{{ rangeVal[0] }}{{ unit }} — {{ rangeVal[1] }}{{ unit }}</span>
+      <span class="pg-field-value" v-else>{{ singleVal }}{{ unit }}</span>
+    </div>
+    <Slider v-if="isRangeMode(optionKey)" v-model="rangeVal" :range="true" :min="min" :max="max" :step="step" />
+    <Slider v-else v-model="singleVal" :min="min" :max="max" :step="step" />
+  </div>
+</template>

--- a/apps/docs/.vitepress/theme/components/playground/PlaygroundTransformSection.vue
+++ b/apps/docs/.vitepress/theme/components/playground/PlaygroundTransformSection.vue
@@ -1,14 +1,13 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import Slider from 'primevue/slider';
-import Button from 'primevue/button';
 import SelectButton from 'primevue/selectbutton';
-import { ArrowLeftRight } from '@lucide/vue';
 import useStore from '@theme/stores/playground';
 import { useRangeField } from '@theme/composables/useRangeField';
+import PlaygroundRangeField from './PlaygroundRangeField.vue';
 
 const store = useStore();
-const { isRangeMode, toggleRangeMode, singleComputed, rangeComputed } = useRangeField(store.avatarStyleOptions);
+const { singleComputed } = useRangeField(store.avatarStyleOptions);
 
 const flipOptions = ['none', 'horizontal', 'vertical', 'both'];
 
@@ -27,15 +26,7 @@ const flip = computed({
   },
 });
 
-const rotateSingle = singleComputed('rotate', 0);
-const rotateRange = rangeComputed('rotate', 0);
-const scaleSingle = singleComputed('scale', 1);
-const scaleRange = rangeComputed('scale', 1);
 const borderRadius = singleComputed('borderRadius', 0);
-const translateXSingle = singleComputed('translateX', 0);
-const translateXRange = rangeComputed('translateX', 0);
-const translateYSingle = singleComputed('translateY', 0);
-const translateYRange = rangeComputed('translateY', 0);
 </script>
 
 <template>
@@ -46,43 +37,24 @@ const translateYRange = rangeComputed('translateY', 0);
         <SelectButton v-model="flip" :options="flipOptions" :allow-empty="false" />
       </div>
 
-      <div class="pg-field">
-        <div class="pg-field-label">
-          <span>Rotate</span>
-          <Button
-            size="small"
-            :severity="isRangeMode('rotate') ? 'primary' : 'secondary'"
-            v-tooltip="isRangeMode('rotate') ? 'Switch to fixed value' : 'Switch to range'"
-            @click="toggleRangeMode('rotate', 0)"
-            class="pg-field-toggle"
-          >
-            <ArrowLeftRight :size="14" />
-          </Button>
-          <span class="pg-field-value" v-if="isRangeMode('rotate')">{{ rotateRange[0] }}° — {{ rotateRange[1] }}°</span>
-          <span class="pg-field-value" v-else>{{ rotateSingle }}°</span>
-        </div>
-        <Slider v-if="isRangeMode('rotate')" v-model="rotateRange" :range="true" :min="-360" :max="360" :step="1" />
-        <Slider v-else v-model="rotateSingle" :min="-360" :max="360" :step="1" />
-      </div>
+      <PlaygroundRangeField
+        label="Rotate"
+        option-key="rotate"
+        :min="-360"
+        :max="360"
+        :step="1"
+        unit="°"
+        :default-single="0"
+      />
 
-      <div class="pg-field">
-        <div class="pg-field-label">
-          <span>Scale</span>
-          <Button
-            size="small"
-            :severity="isRangeMode('scale') ? 'primary' : 'secondary'"
-            v-tooltip="isRangeMode('scale') ? 'Switch to fixed value' : 'Switch to range'"
-            @click="toggleRangeMode('scale', 1)"
-            class="pg-field-toggle"
-          >
-            <ArrowLeftRight :size="14" />
-          </Button>
-          <span class="pg-field-value" v-if="isRangeMode('scale')">{{ scaleRange[0] }} — {{ scaleRange[1] }}</span>
-          <span class="pg-field-value" v-else>{{ scaleSingle }}</span>
-        </div>
-        <Slider v-if="isRangeMode('scale')" v-model="scaleRange" :range="true" :min="0" :max="2" :step="0.01" />
-        <Slider v-else v-model="scaleSingle" :min="0" :max="2" :step="0.01" />
-      </div>
+      <PlaygroundRangeField
+        label="Scale"
+        option-key="scale"
+        :min="0"
+        :max="2"
+        :step="0.01"
+        :default-single="1"
+      />
 
       <div class="pg-field">
         <div class="pg-field-label">
@@ -92,43 +64,25 @@ const translateYRange = rangeComputed('translateY', 0);
         <Slider v-model="borderRadius" :min="0" :max="50" :step="1" />
       </div>
 
-      <div class="pg-field">
-        <div class="pg-field-label">
-          <span>Translate X</span>
-          <Button
-            size="small"
-            :severity="isRangeMode('translateX') ? 'primary' : 'secondary'"
-            v-tooltip="isRangeMode('translateX') ? 'Switch to fixed value' : 'Switch to range'"
-            @click="toggleRangeMode('translateX', 0)"
-            class="pg-field-toggle"
-          >
-            <ArrowLeftRight :size="14" />
-          </Button>
-          <span class="pg-field-value" v-if="isRangeMode('translateX')">{{ translateXRange[0] }}% — {{ translateXRange[1] }}%</span>
-          <span class="pg-field-value" v-else>{{ translateXSingle }}%</span>
-        </div>
-        <Slider v-if="isRangeMode('translateX')" v-model="translateXRange" :range="true" :min="-100" :max="100" :step="1" />
-        <Slider v-else v-model="translateXSingle" :min="-100" :max="100" :step="1" />
-      </div>
+      <PlaygroundRangeField
+        label="Translate X"
+        option-key="translateX"
+        :min="-100"
+        :max="100"
+        :step="1"
+        unit="%"
+        :default-single="0"
+      />
 
-      <div class="pg-field">
-        <div class="pg-field-label">
-          <span>Translate Y</span>
-          <Button
-            size="small"
-            :severity="isRangeMode('translateY') ? 'primary' : 'secondary'"
-            v-tooltip="isRangeMode('translateY') ? 'Switch to fixed value' : 'Switch to range'"
-            @click="toggleRangeMode('translateY', 0)"
-            class="pg-field-toggle"
-          >
-            <ArrowLeftRight :size="14" />
-          </Button>
-          <span class="pg-field-value" v-if="isRangeMode('translateY')">{{ translateYRange[0] }}% — {{ translateYRange[1] }}%</span>
-          <span class="pg-field-value" v-else>{{ translateYSingle }}%</span>
-        </div>
-        <Slider v-if="isRangeMode('translateY')" v-model="translateYRange" :range="true" :min="-100" :max="100" :step="1" />
-        <Slider v-else v-model="translateYSingle" :min="-100" :max="100" :step="1" />
-      </div>
+      <PlaygroundRangeField
+        label="Translate Y"
+        option-key="translateY"
+        :min="-100"
+        :max="100"
+        :step="1"
+        unit="%"
+        :default-single="0"
+      />
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- New `PlaygroundRangeField.vue` encapsulates the toggle-button + single/range slider pattern.
- `PlaygroundTransformSection.vue` uses it for Rotate, Scale, TranslateX, TranslateY (4 fields → 4 prop calls).
- `PlaygroundComponentSection.vue` uses it for Rotate, TranslateX, TranslateY (with style-default range support via `defaultRange` prop).
- Net reduction: ~150 lines of nearly-identical markup.

### Why multiple `useRangeField` instances are safe
Each `<PlaygroundRangeField>` calls `useRangeField` and gets its own local `rangeMode` reactive object. That is fine because:

- `isRangeMode(key)` first checks the local override, then falls back to `Array.isArray(avatarStyleOptions[key])`.
- The truth source is `avatarStyleOptions` (Pinia + localStorage), which is shared across components.
- Each field uses a unique `optionKey`, so the local `rangeMode` overrides never collide.
- On unmount/remount, the new local `rangeMode` is empty and `isRangeMode` automatically returns the correct value from `avatarStyleOptions`.

## Test plan
- [x] `npx vitepress build .` succeeds
- [x] Toggle each affected field between fixed/range mode → values persist
- [x] Pick a style whose component has a default range (e.g. Bottts mouth rotate) → range mode is on by default
- [x] Switch styles in the playground → fields reset/re-key cleanly via parent's `:key="${avatarStyleName}-${comp.name}"`
- [x] Border Radius (single-only) and Flip (SelectButton) remain untouched