### PR TITLE
Extract style option description and example tables to utility

### DIFF
--- a/apps/docs/.vitepress/theme/components/styles/StyleOptionsCard.vue
+++ b/apps/docs/.vitepress/theme/components/styles/StyleOptionsCard.vue
@@ -18,6 +18,7 @@ import StyleOptionsPreview from './StyleOptionsPreview.vue';
 import StyleOptionsCodePanel from './StyleOptionsCodePanel.vue';
 import Message from 'primevue/message';
 import { padColors, unsupportedHttpApiOptions } from '@theme/utils/avatar';
+import { getOptionDescription, getOptionExamples } from '@theme/utils/styleOptionMeta';
 import { styleColorsKey, styleColorsDefault, styleDefaultsKey, styleDefaultsDefault } from './styleOptionsKeys';
 
 export interface OptionValue {
@@ -123,30 +124,9 @@ const possibleValues = computed(() => {
 
 const examples = computed<(string | number | boolean)[] | undefined>(() => {
   if (skipPreview.value) return undefined;
+  if (isWeighted.value && fieldValues.value.length > 0) return undefined;
 
-  if (isWeighted.value && fieldValues.value.length > 0) {
-    return undefined;
-  }
-
-  if (props.name === 'backgroundColor') return colorExamples('background', 5);
-  if (props.name.match(/Color$/)) {
-    const colorName = props.name.slice(0, -'Color'.length);
-    return colorExamples(colorName);
-  }
-  if (props.name.match(/ColorFill$/)) return ['solid', 'linear', 'radial'];
-  if (props.name.match(/ColorFillStops$/)) return [2, 3, 4, 5];
-  if (props.name.match(/ColorAngle$/)) return [0, 90, 180, 270];
-  if (props.name === 'seed') return ['Felix', 'Aneka', 'Mia', 'James'];
-  if (props.name === 'flip') return ['none', 'horizontal', 'vertical', 'both'];
-  if (props.name === 'rotate') return [0, 90, 180, 270];
-  if (props.name === 'scale') return [0.5, 0.75, 1, 1.5];
-  if (props.name === 'borderRadius') return [0, 10, 25, 50];
-  if (props.name === 'size') return [32, 64, 96, 128];
-  if (props.name === 'translateX') return [-50, -25, 0, 25, 50];
-  if (props.name === 'translateY') return [-50, -25, 0, 25, 50];
-  if (props.name === 'fontWeight') return [100, 400, 700, 900];
-
-  return undefined;
+  return getOptionExamples(props.name, colorExamples);
 });
 
 // Prefer curated examples, fall back to possible values
@@ -184,29 +164,7 @@ const headerId = computed(() => {
   return `options-${props.name.replace(/([A-Z])/g, '-$1').toLowerCase()}`;
 });
 
-const description = computed(() => {
-  const n = props.name;
-
-  if (n === 'seed') return 'The seed determines the initial value for the PRNG. With the same seed, the same avatar is generated every time.';
-  if (n === 'size') return 'Output size in pixels. If omitted, the avatar scales to 100% of its container.';
-  if (n === 'idRandomization') return 'Randomizes all SVG element IDs to avoid conflicts when embedding multiple avatars in the same page.';
-  if (n === 'title') return 'Accessible title for the SVG element. Useful for screen readers.';
-  if (n.match(/Probability$/)) return 'Probability that this component appears in the avatar.';
-  if (n.match(/Variant$/)) return 'The visual variant for this component. If multiple values are given, the PRNG picks one.';
-  if (n.match(/Color$/) && !n.match(/ColorFill/)) return 'Hex color value(s). If multiple values are given, the PRNG picks one.';
-  if (n.match(/ColorFill$/)) return 'Fill mode for the color gradient. Only visible when multiple color stops are used.';
-  if (n.match(/ColorFillStops$/)) return 'Number of color stops for gradient fills.';
-  if (n.match(/ColorAngle$/)) return 'Rotation angle for gradient fills in degrees.';
-  if (n === 'flip') return 'Mirror direction for the avatar.';
-  if (n === 'scale') return 'Scale factor. A value of 1 corresponds to the original size. As a range [min, max], the PRNG picks a value in between.';
-  if (n === 'borderRadius') return 'Corner radius as a percentage. 0 = sharp corners, 50 = full circle.';
-  if (n === 'rotate' || n.match(/Rotate$/)) return 'Rotation in degrees. As a range [min, max], the PRNG picks a value in between.';
-  if (n === 'translateX' || n === 'translateY' || n.match(/TranslateX$/) || n.match(/TranslateY$/)) return 'Translation as a percentage of the canvas size. As a range [min, max], the PRNG picks a value in between.';
-  if (n === 'fontFamily') return 'Font family for text elements within the avatar SVG.';
-  if (n === 'fontWeight') return 'Font weight for text elements within the avatar SVG.';
-
-  return undefined;
-});
+const description = computed(() => getOptionDescription(props.name));
 
 interface MetaItem { label: string; value: string }
 

--- a/apps/docs/.vitepress/theme/utils/styleOptionMeta.ts
+++ b/apps/docs/.vitepress/theme/utils/styleOptionMeta.ts
@@ -1,0 +1,55 @@
+/**
+ * Returns a curated description for a style option, or undefined if none exists.
+ * Used by StyleOptionsCard to render help text under each option.
+ */
+export function getOptionDescription(name: string): string | undefined {
+  if (name === 'seed') return 'The seed determines the initial value for the PRNG. With the same seed, the same avatar is generated every time.';
+  if (name === 'size') return 'Output size in pixels. If omitted, the avatar scales to 100% of its container.';
+  if (name === 'idRandomization') return 'Randomizes all SVG element IDs to avoid conflicts when embedding multiple avatars in the same page.';
+  if (name === 'title') return 'Accessible title for the SVG element. Useful for screen readers.';
+  if (name.match(/Probability$/)) return 'Probability that this component appears in the avatar.';
+  if (name.match(/Variant$/)) return 'The visual variant for this component. If multiple values are given, the PRNG picks one.';
+  if (name.match(/Color$/) && !name.match(/ColorFill/)) return 'Hex color value(s). If multiple values are given, the PRNG picks one.';
+  if (name.match(/ColorFill$/)) return 'Fill mode for the color gradient. Only visible when multiple color stops are used.';
+  if (name.match(/ColorFillStops$/)) return 'Number of color stops for gradient fills.';
+  if (name.match(/ColorAngle$/)) return 'Rotation angle for gradient fills in degrees.';
+  if (name === 'flip') return 'Mirror direction for the avatar.';
+  if (name === 'scale') return 'Scale factor. A value of 1 corresponds to the original size. As a range [min, max], the PRNG picks a value in between.';
+  if (name === 'borderRadius') return 'Corner radius as a percentage. 0 = sharp corners, 50 = full circle.';
+  if (name === 'rotate' || name.match(/Rotate$/)) return 'Rotation in degrees. As a range [min, max], the PRNG picks a value in between.';
+  if (name === 'translateX' || name === 'translateY' || name.match(/TranslateX$/) || name.match(/TranslateY$/)) return 'Translation as a percentage of the canvas size. As a range [min, max], the PRNG picks a value in between.';
+  if (name === 'fontFamily') return 'Font family for text elements within the avatar SVG.';
+  if (name === 'fontWeight') return 'Font weight for text elements within the avatar SVG.';
+
+  return undefined;
+}
+
+/**
+ * Returns curated example values for a style option, or undefined if none.
+ * `colorExamples` is a callback that returns colors for a given color name
+ * (so we don't pull `padColors`/`styleColors` into this util).
+ */
+export function getOptionExamples(
+  name: string,
+  colorExamples: (colorName: string, min?: number) => string[],
+): (string | number | boolean)[] | undefined {
+  if (name === 'backgroundColor') return colorExamples('background', 5);
+  if (name.match(/Color$/)) {
+    const colorName = name.slice(0, -'Color'.length);
+    return colorExamples(colorName);
+  }
+  if (name.match(/ColorFill$/)) return ['solid', 'linear', 'radial'];
+  if (name.match(/ColorFillStops$/)) return [2, 3, 4, 5];
+  if (name.match(/ColorAngle$/)) return [0, 90, 180, 270];
+  if (name === 'seed') return ['Felix', 'Aneka', 'Mia', 'James'];
+  if (name === 'flip') return ['none', 'horizontal', 'vertical', 'both'];
+  if (name === 'rotate') return [0, 90, 180, 270];
+  if (name === 'scale') return [0.5, 0.75, 1, 1.5];
+  if (name === 'borderRadius') return [0, 10, 25, 50];
+  if (name === 'size') return [32, 64, 96, 128];
+  if (name === 'translateX') return [-50, -25, 0, 25, 50];
+  if (name === 'translateY') return [-50, -25, 0, 25, 50];
+  if (name === 'fontWeight') return [100, 400, 700, 900];
+
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- New `apps/docs/.vitepress/theme/utils/styleOptionMeta.ts` exports `getOptionDescription(name)` and `getOptionExamples(name, colorExamples)`.
- `StyleOptionsCard.vue` now calls them instead of inlining 80+ lines of `if/else` chains.
- Behaviour-preserving: branch order, regex predicates and the `Color` / `ColorFill` edge case are preserved verbatim.
- Side benefit: future i18n of help texts becomes a single-file change.

### Why a callback for `colorExamples`
`getOptionExamples` takes a `colorExamples` callback rather than importing `padColors` / `styleColors` directly. That keeps the util pure and free of Vue provide/inject dependencies, so it can be unit-tested or reused in other contexts.

## Test plan
- [x] `npx vitepress build .` succeeds
- [x] Visit `/styles/<any>/` → option cards still show their descriptions and curated examples
- [x] Weighted enums: no example list (`isWeighted` guard still in the component)
- [x] `skipPreview` options (boolean / `fontFamily` / `title`): no examples (guard still in the component)