### PR TITLE
DRY up avatar API URL/CLI serializers and fix numeric array over-quoting

### DIFF
--- a/apps/docs/.vitepress/theme/utils/avatar.ts
+++ b/apps/docs/.vitepress/theme/utils/avatar.ts
@@ -329,6 +329,14 @@ function shellQuote(value: string): string {
   return `'${escapeShellArg(value)}'`;
 }
 
+// Numbers and booleans contain no shell-special characters, so they
+// stay unquoted both as single values and inside arrays. Strings get
+// quoted defensively in case they contain spaces, semicolons, etc.
+function formatCliArg(value: unknown): string {
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return shellQuote(String(value));
+}
+
 export function getAvatarApiCommand(
   avatarStyle: string,
   options: Record<string, unknown> = {},
@@ -339,13 +347,10 @@ export function getAvatarApiCommand(
       switch (classified.kind) {
         case 'array':
           return `  --${k} ${classified.values
-            .map((c) => shellQuote(String(c)))
+            .map(formatCliArg)
             .join(' ')}`.trimEnd();
         case 'primitive':
-          if (typeof classified.value === 'string') {
-            return `  --${k} ${shellQuote(classified.value)}`;
-          }
-          return `  --${k} ${classified.value}`;
+          return `  --${k} ${formatCliArg(classified.value)}`;
         case 'object': {
           const pairs = classified.entries
             .map(([vk, vv]) => shellQuote(`${vk}:${vv}`))
@@ -353,7 +358,7 @@ export function getAvatarApiCommand(
           return `  --${k} ${pairs}`;
         }
         case 'string':
-          return `  --${k} ${shellQuote(classified.value)}`;
+          return `  --${k} ${formatCliArg(classified.value)}`;
       }
     })
     .join(' \\\n');

--- a/apps/docs/.vitepress/theme/utils/avatar.ts
+++ b/apps/docs/.vitepress/theme/utils/avatar.ts
@@ -266,6 +266,27 @@ export const unsupportedHttpApiOptions = new Set([
   'title',
 ]);
 
+type ApiOptionValue =
+  | { kind: 'array'; values: unknown[] }
+  | { kind: 'primitive'; value: string | number | boolean }
+  | { kind: 'object'; entries: [string, unknown][] }
+  | { kind: 'string'; value: string };
+
+function classifyOptionValue(value: unknown): ApiOptionValue {
+  if (Array.isArray(value)) return { kind: 'array', values: value };
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return { kind: 'primitive', value };
+  }
+  if (typeof value === 'object' && value !== null) {
+    return { kind: 'object', entries: Object.entries(value) };
+  }
+  return { kind: 'string', value: String(value) };
+}
+
 export function getAvatarApiUrl(
   avatarStyle: string,
   options: Record<string, unknown> = {},
@@ -274,31 +295,28 @@ export function getAvatarApiUrl(
   const qs = Object.entries(options)
     .filter(([k, v]) => v !== undefined && !unsupportedHttpApiOptions.has(k))
     .map(([k, v]) => {
-      if (Array.isArray(v)) {
-        return v.length === 0
-          ? `${encodeURIComponent(k)}[]`
-          : `${encodeURIComponent(k)}=${v
-              .map((c) => encodeURIComponent(c))
-              .join(',')}`;
+      const classified = classifyOptionValue(v);
+      switch (classified.kind) {
+        case 'array':
+          return classified.values.length === 0
+            ? `${encodeURIComponent(k)}[]`
+            : `${encodeURIComponent(k)}=${classified.values
+                .map((c) => encodeURIComponent(String(c)))
+                .join(',')}`;
+        case 'primitive':
+          return `${encodeURIComponent(k)}=${encodeURIComponent(classified.value)}`;
+        case 'object': {
+          const pairs = classified.entries
+            .map(
+              ([vk, vv]) =>
+                `${encodeURIComponent(vk)}:${encodeURIComponent(String(vv))}`,
+            )
+            .join(',');
+          return `${encodeURIComponent(k)}=${pairs}`;
+        }
+        case 'string':
+          return `${encodeURIComponent(k)}=${encodeURIComponent(classified.value)}`;
       }
-
-      if (
-        typeof v == 'string' ||
-        typeof v == 'number' ||
-        typeof v == 'boolean'
-      ) {
-        return `${encodeURIComponent(k)}=${encodeURIComponent(v)}`;
-      }
-
-      if (typeof v === 'object' && v !== null && !Array.isArray(v)) {
-        const pairs = Object.entries(v)
-          .map(([vk, vv]) => `${encodeURIComponent(vk)}:${encodeURIComponent(vv)}`)
-          .join(',');
-
-        return `${encodeURIComponent(k)}=${pairs}`;
-      }
-
-      return `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`;
     })
     .join('&');
 
@@ -317,29 +335,26 @@ export function getAvatarApiCommand(
 ): string {
   const args = Object.entries(options)
     .map(([k, v]) => {
-      if (Array.isArray(v)) {
-        return `  --${k} ${v
-          .map((c) => shellQuote(String(c)))
-          .join(' ')}`.trimEnd();
+      const classified = classifyOptionValue(v);
+      switch (classified.kind) {
+        case 'array':
+          return `  --${k} ${classified.values
+            .map((c) => shellQuote(String(c)))
+            .join(' ')}`.trimEnd();
+        case 'primitive':
+          if (typeof classified.value === 'string') {
+            return `  --${k} ${shellQuote(classified.value)}`;
+          }
+          return `  --${k} ${classified.value}`;
+        case 'object': {
+          const pairs = classified.entries
+            .map(([vk, vv]) => shellQuote(`${vk}:${vv}`))
+            .join(' ');
+          return `  --${k} ${pairs}`;
+        }
+        case 'string':
+          return `  --${k} ${shellQuote(classified.value)}`;
       }
-
-      if (typeof v == 'number' || typeof v == 'boolean') {
-        return `  --${k} ${v}`;
-      }
-
-      if (typeof v == 'string') {
-        return `  --${k} ${shellQuote(v)}`;
-      }
-
-      if (typeof v === 'object' && v !== null && !Array.isArray(v)) {
-        const pairs = Object.entries(v)
-          .map(([vk, vv]) => shellQuote(`${vk}:${vv}`))
-          .join(' ');
-
-        return `  --${k} ${pairs}`;
-      }
-
-      return `  --${k} ${shellQuote(String(v))}`;
     })
     .join(' \\\n');
 


### PR DESCRIPTION
## Summary
1. **DRY refactor.** Extract `classifyOptionValue(value)` helper that returns a discriminated union (`array` / `primitive` / `object` / `string`). Both `getAvatarApiUrl` and `getAvatarApiCommand` now switch on it instead of duplicating Array/string/number/boolean/object branching.
2. **Bug fix while we're here.** Stop over-quoting numeric and boolean array elements in CLI snippets. The original `getAvatarApiCommand` quoted every array element through `shellQuote(String(c))`, so `[90, -90]` rendered as `--rotate '90' '-90'` while a single `90` correctly rendered unquoted as `--rotate 90`. Numbers and booleans contain no shell-special characters and never need quoting; the inconsistency made array snippets uglier than single-value snippets. Extract `formatCliArg(value)` that quotes only strings, and use it in both the `array` and `primitive` branches.

### Verified inputs
| Input | URL | CLI before | CLI after |
| --- | --- | --- | --- |
| `{ seed: 'Felix' }` | `seed=Felix` | `--seed 'Felix'` | `--seed 'Felix'` |
| `{ rotate: 90 }` | `rotate=90` | `--rotate 90` | `--rotate 90` |
| `{ flip: true }` | `flip=true` | `--flip true` | `--flip true` |
| `{ rotate: [90, -90] }` | `rotate=90,-90` | `--rotate '90' '-90'` | **`--rotate 90 -90`** |
| `{ flip: [true, false] }` | `flip=true,false` | `--flip 'true' 'false'` | **`--flip true false`** |
| `{ backgroundColor: ['ff0000','00ff00'] }` | `backgroundColor=ff0000,00ff00` | `--backgroundColor 'ff0000' '00ff00'` | `--backgroundColor 'ff0000' '00ff00'` |
| `{ rotate: [] }` | `rotate[]` | `--rotate` | `--rotate` |
| `{ eyesVariant: { wink: 2, smile: 1 } }` | `eyesVariant=wink:2,smile:1` | `--eyesVariant 'wink:2' 'smile:1'` | `--eyesVariant 'wink:2' 'smile:1'` |

URL output is byte-identical. CLI output is byte-identical for everything except numeric/boolean arrays, where the bug fix produces cleaner snippets.

## Test plan
- [x] `npx vitepress build .` succeeds
- [x] URL/CLI snippets in style options pages render correctly for various option types
- [x] Playground generates URL correctly for single, array, object options
- [x] Empty-array edge case (`rotate: []`) renders `rotate[]` in URL and `--rotate` in CLI
- [x] Numeric array (`[90, -90]`) renders unquoted in CLI snippets