### PR TITLE
Clean up useApiStats and useChartTheme lifecycle

### DIFF
--- a/apps/docs/.vitepress/theme/composables/useApiStats.ts
+++ b/apps/docs/.vitepress/theme/composables/useApiStats.ts
@@ -55,29 +55,25 @@ async function doFetch() {
       monthlyTraffic: traffic.total,
       monthLabel: requests.label,
     };
-  } catch {
-    // silently fail
+  } catch (err) {
+    console.warn('[useApiStats] Failed to fetch stats:', err);
   } finally {
     fetching = null;
   }
 }
 
-function ensureFetched() {
-  onMounted(() => {
-    if (!cached.value && !fetching) {
-      fetching = doFetch();
-    }
-  });
-}
-
 export function useApiStats() {
-  ensureFetched();
+  onMounted(() => {
+    if (!cached.value && !fetching) fetching = doFetch();
+  });
 
   return cached;
 }
 
 export function useApiStatsRaw() {
-  ensureFetched();
+  onMounted(() => {
+    if (!cached.value && !fetching) fetching = doFetch();
+  });
 
   return rawData;
 }

--- a/apps/docs/.vitepress/theme/composables/useChartTheme.ts
+++ b/apps/docs/.vitepress/theme/composables/useChartTheme.ts
@@ -1,18 +1,12 @@
-import { ref, watch } from 'vue';
+import { computed } from 'vue';
 import { useData } from 'vitepress';
-
-const chartKey = ref(0);
-let watcherSet = false;
 
 export function useChartTheme() {
   const { isDark } = useData();
 
-  if (!watcherSet) {
-    watcherSet = true;
-    watch(isDark, () => {
-      chartKey.value++;
-    });
-  }
+  // Flips when the theme toggles; chart components bind it as `:key` to force a
+  // Chart.js remount so new theme colors take effect.
+  const chartKey = computed(() => (isDark.value ? 1 : 0));
 
   function tooltipConfig() {
     return {


### PR DESCRIPTION
## Summary
- **useApiStats:** drop the `ensureFetched` indirection and call `onMounted` directly inside both `useApiStats()` and `useApiStatsRaw()`. Replace the silent `catch {}` with `console.warn` so fetch failures surface in the browser console.
- **useChartTheme:** replace the module-level `ref` + `watcherSet` flag + manual `watch(isDark, ...)` with a per-instance `computed(() => isDark.value ? 1 : 0)`. Components still use it as `:key` to force a Chart.js remount on theme toggle. Side benefit: the previous watcher leaked across the app lifetime; computed cleans up with the component scope and is HMR-safe.

Public API of both composables is unchanged.

## Test plan
- [x] `npx vitepress build .` succeeds
- [x] `/stats/` renders numbers and charts (`useApiStats` API unchanged, `chartKey` still reacts to `isDark`)
- [x] Toggle dark mode → charts re-render with new theme colors (`computed` flips `0 ↔ 1`, `:key` changes, Chart.js remounts)
- [x] Fetch failures surface in the browser console instead of silently failing
- [x] Public API unchanged — all existing consumers compile