### PR TITLE
Add 5s timeout to GitHub stars fetch in config

### DIFF
--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -21,17 +21,24 @@ async function fetchGitHubStars(
   repos: string[],
 ): Promise<Record<string, string>> {
   const result: Record<string, string> = {};
+  const TIMEOUT_MS = 5000;
 
   await Promise.all(
     repos.map(async (repo) => {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
       try {
-        const res = await fetch(`https://api.github.com/repos/${repo}`);
+        const res = await fetch(`https://api.github.com/repos/${repo}`, {
+          signal: controller.signal,
+        });
         if (res.ok) {
           const data = await res.json();
           result[repo] = formatStars(data.stargazers_count);
         }
       } catch {
-        // Ignore fetch errors, fallback handled in components
+        // Ignore fetch/timeout errors, fallback handled in components
+      } finally {
+        clearTimeout(timer);
       }
     }),
   );


### PR DESCRIPTION
## Summary
- Wrap each `fetch` in `fetchGitHubStars` with an `AbortController` that aborts after 5 s.
- Clear the timer in `finally` so it cannot leak past a successful response.
- The existing `catch {}` already absorbs failures (and now also `AbortError`), and components have hard-coded star fallbacks (e.g. `'8k+'`), so a timeout simply lets the build proceed with empty stars instead of hanging indefinitely.

`AbortController` is part of Node ≥ 18; this app requires Node ≥ 20.

## Test plan
- [x] `npx vitepress build .` succeeds and completes well under 5 s
- [x] Components still have hard-coded fallbacks (`'8k+'`, etc.) for the worst case
- [ ] (manual) Block api.github.com via /etc/hosts → build still completes within ~5 s