### PR TITLE
Clean up useVariantWeights: multi-source watch, JSDoc, drop legacy string handling

### DIFF
--- a/apps/docs/.vitepress/theme/composables/useVariantWeights.ts
+++ b/apps/docs/.vitepress/theme/composables/useVariantWeights.ts
@@ -11,7 +11,6 @@ import type { PlaygroundStoreOptions } from '@theme/types';
  *
  * Storage formats in `avatarStyleOptions[<componentName>Variant]`:
  * - undefined → use the style's default weights
- * - string    → a single variant name (legacy single-pick form)
  * - string[]  → list of active variants, each implicitly weight 1
  * - object    → { variant: weight } map (when showWeights is on)
  *
@@ -67,10 +66,6 @@ export function useVariantWeights(
         return Object.fromEntries(
           currentVariants.map((v) => [v, v in obj ? obj[v] : undefined]),
         );
-      }
-
-      if (typeof val === 'string') {
-        return Object.fromEntries(currentVariants.map((v) => [v, v === val ? 1 : undefined]));
       }
 
       return Object.fromEntries(currentVariants.map((v) => [v, 1]));

--- a/apps/docs/.vitepress/theme/composables/useVariantWeights.ts
+++ b/apps/docs/.vitepress/theme/composables/useVariantWeights.ts
@@ -1,10 +1,23 @@
 import { computed, ref, watch, type Ref } from 'vue';
 import type { PlaygroundStoreOptions } from '@theme/types';
 
-// Manages the 3-state variant weight system:
-// - undefined = excluded (not in object, never considered)
-// - 0 = active with weight 0 (fallback when all others also 0)
-// - > 0 = active with that weight
+/**
+ * Manages variant weights for a component option in the playground.
+ *
+ * Variant weight states:
+ * - undefined → variant is excluded (not in the options object at all)
+ * - 0         → variant is active but with weight 0 (rare, used as fallback)
+ * - > 0       → variant is active with that weight
+ *
+ * Storage formats in `avatarStyleOptions[<componentName>Variant]`:
+ * - undefined → use the style's default weights
+ * - string    → a single variant name (legacy single-pick form)
+ * - string[]  → list of active variants, each implicitly weight 1
+ * - object    → { variant: weight } map (when showWeights is on)
+ *
+ * The composable transparently converts between these formats based on
+ * `showWeights` and the user's interactions.
+ */
 export function useVariantWeights(
   avatarStyleOptions: PlaygroundStoreOptions,
   componentName: Ref<string> | (() => string),
@@ -23,14 +36,14 @@ export function useVariantWeights(
 
   // Re-initialize showWeights when component/style changes
   watch(
-    () => `${getName()}-${getVariants().length}-${getNonDefault()}`,
+    [() => getName(), () => getVariants(), () => getNonDefault()],
     () => {
       const storeVal = avatarStyleOptions[variantKey.value];
 
       showWeights.value =
         (typeof storeVal === 'object' && !Array.isArray(storeVal)) || getNonDefault();
     },
-    { immediate: true },
+    { deep: true, immediate: true },
   );
 
   const variantWeights = computed<Record<string, number | undefined>>({


### PR DESCRIPTION
## Summary
1. **Multi-source watch.** Replace the brittle string-concatenated watch source `\`\${getName()}-\${getVariants().length}-\${getNonDefault()}\`` with a proper multi-source watch on `[getName, getVariants, getNonDefault]`. Add `{ deep: true }` so variant array content changes (not just length) trigger the `showWeights` re-init.
2. **JSDoc state machine.** Promote the inline comment into a JSDoc block over the function documenting the weight states and the storage formats in one place.
3. **Drop legacy single-string variant handling.** The `variantWeights` getter had a fallthrough branch that interpreted a single string as "only this variant is active". No current write path produces a string in `avatarStyleOptions[<componentName>Variant]` — the `useVariantWeights` setter only writes `Array` or `Object`, and `componentPreview` / `getComponentVisibilityOptions` use local option dicts that never reach the playground store. The branch only protected stale localStorage from earlier versions; removing it lets such stale entries fall through to the default-all branch and the next user toggle rewrites the store to the new format.

Public API of `useVariantWeights` is unchanged.

## Test plan
- [x] `npx vitepress build .` succeeds
- [x] Style switch in playground re-initializes `showWeights` for components with different variants (multi-source watch with `deep: true`)
- [x] Toggle "show weights" in the playground → values persist
- [x] Public API unchanged — all existing consumers compile