### PR TITLE
Reduce contributor guide duplication and fix markdown trailing space

### DIFF
--- a/apps/docs/pages/guides/contribute-to-the-library/index.md
+++ b/apps/docs/pages/guides/contribute-to-the-library/index.md
@@ -147,6 +147,8 @@ calling the CLI script directly as follows:
 node src/js/cli/bin/index.js <COMMAND>
 ```
 
+<!-- The Branching and committing / Creating a Pull Request steps below intentionally parallel the style-contributor sections above. The branch and commit placeholders differ (generic <YOUR_BRANCH> / "Change:" prefix vs. style-specific), so both variants are kept for clarity. Update both if changing. -->
+
 ### Branching and committing
 
 Once you are happy with the changes, create a branch so you can commit the
@@ -166,9 +168,8 @@ git push origin <YOUR_BRANCH>
 
 ### Creating a Pull Request
 
-Follow
-[these instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork)
-to create a Pull Request.
+See
+[Creating a Pull Request](#creating-a-pull-request) above for instructions.
 
 ## Releasing new versions (maintainers only)
 

--- a/apps/docs/pages/how-to-use/js-library/converter/index.md
+++ b/apps/docs/pages/how-to-use/js-library/converter/index.md
@@ -198,7 +198,7 @@ const png = toPng(svg, {
 const buffer = await png.toArrayBuffer(); // [!code focus]
 ```
 
-## Options 
+## Options
 
 | Option        | Type       | Default | Environment       | Description                               |
 | ------------- | ---------- | ------- | ----------------- | ----------------------------------------- |


### PR DESCRIPTION
## Summary
- `contribute-to-the-library/index.md`: replace the second "Creating a Pull Request" section's verbatim instructions with a back-link to the first section, and add an HTML comment explaining the intentional parallel structure for the surrounding "Branching and committing" sections (the branch and commit prefixes differ between style and package contributors).
- `converter/index.md`: drop a trailing space on the "## Options" heading.

## Test plan
- [x] `npx vitepress build .` succeeds
- [ ] Visit `/guides/contribute-to-the-library/` → both contributor flows still readable, internal anchor works