### PR TITLE
docs: replace v-html headlines with slot-based section headers

### DIFF
--- a/apps/docs/.vitepress/theme/components/app/AppCDN.vue
+++ b/apps/docs/.vitepress/theme/components/app/AppCDN.vue
@@ -29,9 +29,10 @@ const stats = computed(() => [
       <UiSectionHeader
         class="app-cdn-header"
         badge="Content Delivery Network"
-        headline="Lightning fast, <strong>globally delivered</strong>"
         description="Our HTTP-API is powered by a global CDN — delivering avatars with low latency, high reliability, and completely free of charge."
-      />
+      >
+        <template #headline>Lightning fast, <strong>globally delivered</strong></template>
+      </UiSectionHeader>
 
       <div class="app-cdn-content">
         <UiCard padding="xl" radius="lg" class="app-cdn-card">

--- a/apps/docs/.vitepress/theme/components/app/AppComparison.vue
+++ b/apps/docs/.vitepress/theme/components/app/AppComparison.vue
@@ -138,9 +138,10 @@ function getCellValue(row: ComparisonRow, key: keyof ComparisonRow): CellValue {
       <UiSectionHeader
         class="app-comparison-header"
         badge="Comparison"
-        headline="How DiceBear <strong>Compares</strong>"
         description="Every tool has its strengths. Choose what works best for your project."
-      />
+      >
+        <template #headline>How DiceBear <strong>Compares</strong></template>
+      </UiSectionHeader>
 
       <UiCard padding="md" radius="lg" class="app-comparison-table-card">
         <div class="app-comparison-table-wrapper">

--- a/apps/docs/.vitepress/theme/components/app/AppCreateStyle.vue
+++ b/apps/docs/.vitepress/theme/components/app/AppCreateStyle.vue
@@ -34,9 +34,10 @@ const steps = [
       <UiSectionHeader
         badge="For Artists"
         badge-variant="green"
-        headline="Create Your Own Style<br /><strong>with Figma</strong>"
         description="Design your avatar style visually in Figma. Our plugin handles the technical export – no coding required."
-      />
+      >
+        <template #headline>Create Your Own Style<br /><strong>with Figma</strong></template>
+      </UiSectionHeader>
 
       <div class="app-create-style-grid">
         <div class="app-create-style-content">

--- a/apps/docs/.vitepress/theme/components/app/AppFrameworks.vue
+++ b/apps/docs/.vitepress/theme/components/app/AppFrameworks.vue
@@ -24,9 +24,10 @@ const frameworks = [
     <UiContainer class="app-frameworks-container">
       <UiSectionHeader
         badge="Framework Support"
-        headline="Works with Your <strong>Favorite</strong> Framework"
         description="Use DiceBear with React, Vue, Svelte, Angular and more. Simply use our HTTP-API as image source or install the JS-library."
-      />
+      >
+        <template #headline>Works with Your <strong>Favorite</strong> Framework</template>
+      </UiSectionHeader>
 
       <div class="app-frameworks-grid">
         <a

--- a/apps/docs/.vitepress/theme/components/app/AppHighlights.vue
+++ b/apps/docs/.vitepress/theme/components/app/AppHighlights.vue
@@ -11,7 +11,7 @@ withDefaults(defineProps<{
   description?: string;
 }>(), {
   badge: 'Why DiceBear?',
-  headline: 'Built for <strong>Developers</strong>, Loved by Users',
+  headline: 'Built for Developers, Loved by Users',
   description: 'Everything you need to create beautiful, unique avatars for your applications.',
 });
 
@@ -67,9 +67,12 @@ const highlights = [
       <UiSectionHeader
         class="app-highlights-header"
         :badge="badge"
-        :headline="headline"
         :description="description"
-      />
+      >
+        <template #headline>
+          <slot name="headline">{{ headline }}</slot>
+        </template>
+      </UiSectionHeader>
 
       <div class="app-highlights-grid">
         <UiCard

--- a/apps/docs/.vitepress/theme/components/app/AppIntegration.vue
+++ b/apps/docs/.vitepress/theme/components/app/AppIntegration.vue
@@ -30,9 +30,10 @@ const svg = new Avatar(style, {
       <UiSectionHeader
         class="app-integration-header"
         badge="Easy to Use"
-        headline="Integrate in <strong>Minutes</strong>"
         description="Choose the integration that works best for your project."
-      />
+      >
+        <template #headline>Integrate in <strong>Minutes</strong></template>
+      </UiSectionHeader>
 
       <!-- JS Library - Featured / Full Width -->
       <div class="app-integration-featured app-integration-item" :style="{ animationDelay: '0s' }">

--- a/apps/docs/.vitepress/theme/components/app/AppSmallHero.vue
+++ b/apps/docs/.vitepress/theme/components/app/AppSmallHero.vue
@@ -4,14 +4,14 @@ import { Play, ArrowRight } from '@lucide/vue';
 import { UiButton, UiHeadline, UiDescription, UiBadge, UiContainer, UiSection } from '../ui';
 import { useVisibility } from '../../composables/useVisibility';
 
-const props = withDefaults(defineProps<{
+withDefaults(defineProps<{
   badge?: string;
   headline?: string;
   description?: string;
 }>(), {
   badge: 'Why DiceBear?',
-  headline: 'Avatars That <strong>Stand Out</strong>',
-  description: 'DiceBear is an open source avatar library that lets you generate unique, deterministic profile pictures in no time. Whether you need geometric shapes, cute characters, or pixel art &mdash; our privacy-focused SVG avatar library with 30+ styles brings your projects to life.',
+  headline: 'Avatars That Stand Out',
+  description: 'DiceBear is an open source avatar library that lets you generate unique, deterministic profile pictures in no time. Whether you need geometric shapes, cute characters, or pixel art — our privacy-focused SVG avatar library with 30+ styles brings your projects to life.',
 });
 
 const sectionRef = ref();
@@ -31,8 +31,12 @@ const hasActions = computed(() => !!slots.actions);
       <div :class="{ 'app-small-hero-layout': hasAside }">
         <div>
           <UiBadge>{{ badge }}</UiBadge>
-          <UiHeadline tag="h1"><span v-html="headline" /></UiHeadline>
-          <UiDescription class="app-small-hero-description" v-html="description" />
+          <UiHeadline tag="h1">
+            <slot name="headline">{{ headline }}</slot>
+          </UiHeadline>
+          <UiDescription class="app-small-hero-description">
+            <slot name="description">{{ description }}</slot>
+          </UiDescription>
 
           <div v-if="hasActions" class="app-small-hero-actions">
             <slot name="actions" />

--- a/apps/docs/.vitepress/theme/components/app/AppStatsBanner.vue
+++ b/apps/docs/.vitepress/theme/components/app/AppStatsBanner.vue
@@ -47,9 +47,10 @@ const metrics = computed(() => [
       <UiSectionHeader
         class="app-stats-banner-header"
         badge="Trusted at Scale"
-        headline="Billions of avatars. <strong>One API.</strong>"
         description="Real usage data from our HTTP-API and npm packages — updated daily."
-      />
+      >
+        <template #headline>Billions of avatars. <strong>One API.</strong></template>
+      </UiSectionHeader>
 
       <div class="app-stats-banner-grid">
         <UiCard

--- a/apps/docs/.vitepress/theme/components/app/AppStyleShowcase.vue
+++ b/apps/docs/.vitepress/theme/components/app/AppStyleShowcase.vue
@@ -152,9 +152,10 @@ onUnmounted(() => {
     <UiContainer class="app-style-showcase-header">
       <UiSectionHeader
         badge="Explore the Collection"
-        headline="<strong>30+</strong> Unique Avatar Styles"
         description="From cute characters to abstract patterns, pixel art to professional illustrations. Our avatar library features styles crafted by talented artists and designers."
-      />
+      >
+        <template #headline><strong>30+</strong> Unique Avatar Styles</template>
+      </UiSectionHeader>
     </UiContainer>
 
     <div class="app-style-showcase-outer">

--- a/apps/docs/.vitepress/theme/components/app/AppUseCases.vue
+++ b/apps/docs/.vitepress/theme/components/app/AppUseCases.vue
@@ -69,9 +69,10 @@ const useCases = [
       <UiSectionHeader
         class="app-use-cases-header"
         badge="Use Cases"
-        headline="Built for <strong>Every</strong> Application"
         description="From startups to enterprises, DiceBear powers random user avatars across all kinds of products."
-      />
+      >
+        <template #headline>Built for <strong>Every</strong> Application</template>
+      </UiSectionHeader>
 
       <div class="app-use-cases-grid">
         <UiCard

--- a/apps/docs/.vitepress/theme/components/pages/PageStats.vue
+++ b/apps/docs/.vitepress/theme/components/pages/PageStats.vue
@@ -113,11 +113,9 @@ const monthlyStats = computed(() => {
 </script>
 
 <template>
-  <AppSmallHero
-    badge="Statistics"
-    headline="Billions of Avatars.<br><strong>One API.</strong>"
-    description="Every avatar generated through our HTTP-API is tracked anonymously. This page gives you a transparent look at real usage data &mdash; updated daily, broken down by requests, traffic, styles, and more."
-  >
+  <AppSmallHero badge="Statistics">
+    <template #headline>Billions of Avatars.<br><strong>One API.</strong></template>
+    <template #description>Every avatar generated through our HTTP-API is tracked anonymously. This page gives you a transparent look at real usage data — updated daily, broken down by requests, traffic, styles, and more.</template>
     <template #actions><!-- no actions --></template>
     <template #below-actions>
       <div v-if="monthlyStats" class="page-stats-hero-kpis">
@@ -162,9 +160,10 @@ const monthlyStats = computed(() => {
     <UiContainer>
       <UiSectionHeader
         badge="Daily Trends"
-        headline="Usage Over <strong>Time</strong>"
         description="Daily request and download volumes — toggle between the HTTP API and npm packages."
-      />
+      >
+        <template #headline>Usage Over <strong>Time</strong></template>
+      </UiSectionHeader>
 
       <div class="page-stats-tabs">
         <button
@@ -215,9 +214,10 @@ const monthlyStats = computed(() => {
     <UiContainer>
       <UiSectionHeader
         badge="Breakdown"
-        headline="Usage <strong>Details</strong>"
         description="Based on API request data — which styles, versions, and output formats are used most."
-      />
+      >
+        <template #headline>Usage <strong>Details</strong></template>
+      </UiSectionHeader>
 
       <ClientOnly>
         <UiCard v-if="stylesData" class="page-stats-styles-card">

--- a/apps/docs/.vitepress/theme/components/pages/PageWhyDiceBear.vue
+++ b/apps/docs/.vitepress/theme/components/pages/PageWhyDiceBear.vue
@@ -16,7 +16,9 @@ import AppCTA from '../app/AppCTA.vue';
       <AppHeroAsideUserList />
     </template>
   </AppSmallHero>
-  <AppHighlights badge="Features" headline="Everything You <strong>Need</strong>" />
+  <AppHighlights badge="Features">
+    <template #headline>Everything You <strong>Need</strong></template>
+  </AppHighlights>
   <AppIntegration />
   <AppFrameworks />
   <AppCDN />

--- a/apps/docs/.vitepress/theme/components/ui/UiSectionHeader.vue
+++ b/apps/docs/.vitepress/theme/components/ui/UiSectionHeader.vue
@@ -6,7 +6,7 @@ import UiDescription from './UiDescription.vue';
 defineProps<{
   badge?: string;
   badgeVariant?: 'brand' | 'green' | 'orange';
-  headline: string;
+  headline?: string;
   description?: string;
   tag?: 'h1' | 'h2' | 'h3';
 }>();
@@ -19,9 +19,11 @@ defineProps<{
       {{ badge }}
     </UiBadge>
     <UiHeadline :tag="tag">
-      <span v-html="headline" />
+      <slot name="headline">{{ headline }}</slot>
     </UiHeadline>
-    <UiDescription v-if="description">{{ description }}</UiDescription>
+    <UiDescription v-if="$slots.description || description">
+      <slot name="description">{{ description }}</slot>
+    </UiDescription>
     <slot name="after-description" />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- `UiSectionHeader` and `AppSmallHero` rendered the `headline` / `description` string props via `v-html` so callers could embed inline `<strong>` / `<br>` markup. There is no real XSS exposure today (all 14 call sites pass hardcoded literals), but the API forces every caller to escape ahead of time and would be unsafe if ever wired to dynamic data.
- Converted both components to named slots (`#headline` / `#description`) with the props kept as plain-text fallbacks.
- `AppHighlights` forwards an `#headline` slot to the underlying `UiSectionHeader`, so `PageWhyDiceBear` can still pass inline markup via a slot template instead of an HTML string prop.
- Updated all 14 call sites in `apps/docs/.vitepress/theme/components/{app,pages}` to use slot templates where they previously embedded `<strong>` / `<br>`.
- Replaced literal `&mdash;` HTML entities in default prop values with the actual em-dash character `—` so plain-text rendering matches the original visual output.

After the change, `v-html` no longer appears in `UiSectionHeader.vue` or `AppSmallHero.vue`, and no callsite passes `<` or `&mdash;` through a string prop.

## Test plan
- [x] `cd apps/docs && npm run build` succeeds
- [x] Verified rendered HTML in `.vitepress/dist/**/index.html` still contains every expected `<strong>...</strong>` (Compares, One API, 30+, Need, Time, Details, Every, Favorite, Minutes, globally delivered, with Figma)
- [x] Verified the AppSmallHero default headline ("Avatars That Stand Out") renders as plain text on `/why-dicebear/`