### PR TITLE
docs: extract useStyleFiltering config constants

### DIFF
--- a/apps/docs/.vitepress/theme/composables/useStyleFiltering.ts
+++ b/apps/docs/.vitepress/theme/composables/useStyleFiltering.ts
@@ -1,38 +1,18 @@
 import { ref, computed, Ref } from 'vue';
 import { kebabCase, capitalCase } from 'change-case';
 import type { CustomStyleEntry } from '@theme/types';
+import {
+  categoryOrder,
+  previewSeeds,
+  getStyleCategory,
+  normalizeLicense,
+} from '@theme/config/styleCategories';
 
 interface StyleMeta {
   meta: {
     license?: { name?: string };
     creator?: string;
   };
-}
-
-const minimalistStyles = new Set([
-  'glass',
-  'identicon',
-  'rings',
-  'shapes',
-  'initials',
-  'icons',
-  'thumbs',
-]);
-
-function getCategory(name: string): string {
-  return minimalistStyles.has(name) ? 'Minimalist' : 'Characters';
-}
-
-const categoryOrder = ['Custom', 'Minimalist', 'Characters', 'Other'];
-
-const seeds = ['Felix', 'Aneka', 'Milo', 'Luna'];
-
-function normalizeLicense(license: string): string {
-  if (license.includes('CC BY 4.0')) return 'CC BY 4.0';
-  if (license.includes('CC0 1.0')) return 'CC0 1.0';
-  if (license.includes('MIT')) return 'MIT';
-
-  return 'Other';
 }
 
 export function useStyleFiltering(
@@ -55,9 +35,9 @@ export function useStyleFiltering(
           creator: style.meta.creator || 'Unknown',
           license: rawLicense,
           licenseNormalized: normalizeLicense(rawLicense),
-          category: getCategory(kebabCase(styleName)),
+          category: getStyleCategory(kebabCase(styleName)),
           isCustom: false,
-          avatars: seeds.map((seed) => ({
+          avatars: previewSeeds.map((seed) => ({
             seed,
           })),
         };
@@ -75,7 +55,7 @@ export function useStyleFiltering(
       licenseNormalized: 'Unknown',
       category: 'Custom',
       isCustom: true,
-      avatars: seeds.map((seed) => ({
+      avatars: previewSeeds.map((seed) => ({
         seed,
       })),
     }));

--- a/apps/docs/.vitepress/theme/config/styleCategories.ts
+++ b/apps/docs/.vitepress/theme/config/styleCategories.ts
@@ -1,0 +1,25 @@
+const minimalistStyles = new Set([
+  'glass',
+  'identicon',
+  'rings',
+  'shapes',
+  'initials',
+  'icons',
+  'thumbs',
+]);
+
+export const categoryOrder = ['Custom', 'Minimalist', 'Characters', 'Other'];
+
+export const previewSeeds = ['Felix', 'Aneka', 'Milo', 'Luna'];
+
+export function getStyleCategory(name: string): string {
+  return minimalistStyles.has(name) ? 'Minimalist' : 'Characters';
+}
+
+export function normalizeLicense(license: string): string {
+  if (license.includes('CC BY 4.0')) return 'CC BY 4.0';
+  if (license.includes('CC0 1.0')) return 'CC0 1.0';
+  if (license.includes('MIT')) return 'MIT';
+
+  return 'Other';
+}


### PR DESCRIPTION
## Summary
- Move `minimalistStyles`, `categoryOrder`, `previewSeeds` (was `seeds`), `getStyleCategory` (was `getCategory`), and `normalizeLicense` out of `useStyleFiltering.ts` into a new `config/styleCategories.ts` module.
- The composable now imports these from `@theme/config/styleCategories`. Public API (`{ searchQuery, selectedLicense, selectedCategory, allStyles, availableLicenses, availableCategories, styleList, groupedStyles, totalStyles, hasActiveFilters, clearFilters }`) is unchanged.
- Editing the category list, the preview seed list, or the license normalization rules no longer requires touching the composable.

## Test plan
- [x] `cd apps/docs && npm run build` succeeds
- [x] `npx eslint apps/docs/.vitepress/theme/composables/useStyleFiltering.ts apps/docs/.vitepress/theme/config/styleCategories.ts` passes