### PR TITLE
docs: simplify readAllBytes via Response.arrayBuffer

### DIFF
--- a/apps/docs/.vitepress/theme/utils/avatar.ts
+++ b/apps/docs/.vitepress/theme/utils/avatar.ts
@@ -205,27 +205,7 @@ export function styleUsesVariable(avatarStyle: string, variableName: string): bo
 }
 
 async function readAllBytes(readable: ReadableStream<Uint8Array>): Promise<Uint8Array> {
-  const chunks: Uint8Array[] = [];
-  const reader = readable.getReader();
-
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    chunks.push(value);
-  }
-
-  const result = new Uint8Array(
-    chunks.reduce((sum, c) => sum + c.length, 0),
-  );
-
-  let offset = 0;
-
-  for (const chunk of chunks) {
-    result.set(chunk, offset);
-    offset += chunk.length;
-  }
-
-  return result;
+  return new Uint8Array(await new Response(readable).arrayBuffer());
 }
 
 export async function compressFragment(data: object): Promise<string> {


### PR DESCRIPTION
## Summary
- The hand-rolled loop in `readAllBytes` that collected `ReadableStream<Uint8Array>` chunks and copied them into a fresh `Uint8Array` duplicates what `new Response(stream).arrayBuffer()` already does natively — a single allocation, no manual offset tracking.
- Replace the 23-line implementation with a one-liner. Function signature is identical, so call sites in `compressFragment` and `decompressFragment` are unchanged.

The original plan also called for replacing the 31-entry hand-maintained `definitionImports` map with `import.meta.glob`. That change was dropped because `@dicebear/definitions` resolves through its package `exports` field (`./adventurer.json` → `./dist/adventurer.min.json`), and Vite's `import.meta.glob` requires file-system paths, not package exports. A glob through `node_modules/@dicebear/definitions/dist/*.min.json` would bypass the exports field and break on layout changes. The current hand-maintained map is the right tradeoff.

## Test plan
- [x] `cd apps/docs && npm run build` succeeds
- [x] Style pages still prerender (`adventurer`, `pixel-art`, `toon-head` all present in `.vitepress/dist/styles/<style>/index.html`)