### PR TITLE
docs: dedupe formatStars and surface GitHub stars fetch failures

### DIFF
--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -5,17 +5,7 @@ import { ThemeOptions } from '@theme/types';
 import sidebarDocs from './config/sidebarDocs';
 import sidebarStyles from './config/sidebarStyles';
 import avatarStyles from './config/avatarStyles';
-
-
-function formatStars(count: number): string {
-  if (count >= 1000) {
-    const k = Math.floor((count / 1000) * 10) / 10;
-
-    return `${k}k+`;
-  }
-
-  return `${count}+`;
-}
+import { formatStars } from './theme/utils/format';
 
 async function fetchGitHubStars(
   repos: string[],
@@ -35,8 +25,11 @@ async function fetchGitHubStars(
           const data = await res.json();
           result[repo] = formatStars(data.stargazers_count);
         }
-      } catch {
-        // Ignore fetch/timeout errors, fallback handled in components
+      } catch (err) {
+        console.warn(
+          `[github-stars] failed for ${repo}:`,
+          err instanceof Error ? err.message : err,
+        );
       } finally {
         clearTimeout(timer);
       }

--- a/apps/docs/.vitepress/theme/utils/format.ts
+++ b/apps/docs/.vitepress/theme/utils/format.ts
@@ -18,3 +18,13 @@ export function formatBytes(bytes: number): string {
 
   return `${bytes}`;
 }
+
+export function formatStars(count: number): string {
+  if (count >= 1000) {
+    const k = Math.floor((count / 1000) * 10) / 10;
+
+    return `${k}k+`;
+  }
+
+  return `${count}+`;
+}


### PR DESCRIPTION
## Summary
- Move `formatStars` from `apps/docs/.vitepress/config.ts` into `apps/docs/.vitepress/theme/utils/format.ts` next to `formatNumber`/`formatBytes`, and import it from the config.
- Replace the silent `catch {}` in `fetchGitHubStars` with `console.warn` so build-time fetch failures (timeouts, rate limits, network errors) surface in the build log instead of silently producing stale star counts.

The existing `AbortController` / 5s `TIMEOUT_MS` setup is preserved unchanged.

## Test plan
- [x] `cd apps/docs && npm run build` succeeds