### PR TITLE
docs: strip prototype-pollution keys when parsing share fragments

### DIFF
--- a/apps/docs/.vitepress/theme/utils/avatar.ts
+++ b/apps/docs/.vitepress/theme/utils/avatar.ts
@@ -223,6 +223,20 @@ export async function compressFragment(data: object): Promise<string> {
   return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
+// Keys that would let a malicious fragment poison a target object's
+// prototype chain when later merged via Object.assign / property writes.
+// JSON.parse exposes them as own enumerable data properties, so we strip
+// them at parse time via the reviver — recursively across the whole tree.
+const FORBIDDEN_FRAGMENT_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function stripPrototypeKeys(key: string, value: unknown): unknown {
+  if (FORBIDDEN_FRAGMENT_KEYS.has(key)) {
+    return undefined;
+  }
+
+  return value;
+}
+
 export async function decompressFragment(encoded: string): Promise<object> {
   const base64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
   const binary = atob(base64);
@@ -236,7 +250,7 @@ export async function decompressFragment(encoded: string): Promise<object> {
   const decompressed = await readAllBytes(ds.readable);
   const json = new TextDecoder().decode(decompressed);
 
-  return JSON.parse(json);
+  return JSON.parse(json, stripPrototypeKeys);
 }
 
 export const unsupportedHttpApiOptions = new Set([


### PR DESCRIPTION
## Summary

`decompressFragment` is the gateway for the playground's `#data=` URL fragment. `JSON.parse` turns `__proto__` / `constructor` / `prototype` keys into **own enumerable data properties** on the result object, and the playground later merges `payload.options` into the reactive store via `Object.assign`. `Object.assign` calls `[[Set]]` for each key, and `__proto__` triggers `Object.prototype.__proto__`'s setter — replacing the store object's prototype with attacker-controlled data.

Pollution is local to the store object (not global `Object.prototype`), but any downstream `key in opts` or unguarded property access could observe attacker-supplied keys.

## Fix

Pass a reviver to `JSON.parse` that drops the three forbidden keys at every depth. The result object is clean from the moment `decompressFragment` returns:

- **Source-level fix** — every current and future caller of `decompressFragment` is protected automatically.
- **Recursive** — `__proto__` keys nested inside `options.someComponent` are also stripped, not just at the top level.
- **No tainted intermediate** — unlike post-parse sanitization, the result object never exists with the dangerous own keys present.
- Legitimate options pass through unchanged.

## Reproduction (before fix)

Hand-crafted malicious fragment hash: `FcfBCcAwCAXQXf45E3jrJFKIh0CqYkxLCdm99N3ewsi3CwhnvUVzhgQKzLOZDtACs4elMf9p46hXU1DGlAK33mdKBcEflYq99wc`

Decoded payload (without the reviver): `{"style":"adventurer","options":{"__proto__":{"isAdmin":true,"polluted":"pwned"}}}`

Without this PR:
```js
const target = {};
Object.assign(target, payload.options);
Object.getPrototypeOf(target) === Object.prototype  // false — POLLUTED
target.isAdmin                                       // true
```

With this PR (reviver applied during parse):
```js
payload.options                                      // {} — empty
Object.getPrototypeOf(target) === Object.prototype  // true
target.isAdmin                                       // undefined
```

## Test plan
- [x] `cd apps/docs && npm run build` succeeds
- [x] Empirical reviver test in node: malicious fragment decoded → `Object.keys(payload.options)` is empty, `Object.assign(target, payload.options)` leaves `target`'s prototype intact
- [x] Legitimate fragments (`{seed: 'Felix', backgroundColor: ['b6e3f4']}`) pass through unchanged