### PR TITLE
feat(core): add Python port (dicebear-core)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,3 +49,27 @@ jobs:
           fi
 
       - run: node scripts/publish.mjs "$DIST_TAG"
+
+  publish-python:
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build dicebear-core
+        working-directory: src/python/core
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      # Trusted Publishing (OIDC) — no token. Configure the publisher on PyPI:
+      # project dicebear-core, repo dicebear/dicebear, workflow publish.yml.
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: src/python/core/dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,3 +51,31 @@ jobs:
       - name: Run tests
         working-directory: src/php/core
         run: vendor/bin/phpunit
+
+  test-python:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+
+    steps:
+      - uses: actions/checkout@v5
+      - name: Use Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        working-directory: src/python/core
+        run: pip install -e ".[dev]"
+      - name: Run Ruff
+        working-directory: src/python/core
+        run: |
+          ruff check .
+          ruff format --check .
+      - name: Run mypy
+        working-directory: src/python/core
+        run: mypy src
+      - name: Run tests
+        working-directory: src/python/core
+        run: pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 Thanks for your interest in contributing to DiceBear.
 
-This is the main monorepo: the JavaScript and PHP core libraries, the CLI, the
-docs site, and the editor all live here. Repositories covering the JSON Schema,
+This is the main monorepo: the JavaScript, PHP, and Python core libraries, the
+CLI, the docs site, and the editor all live here. Repositories covering the JSON Schema,
 the avatar style definitions, the HTTP API, and the Figma exporter are separate
 and each have their own `CONTRIBUTING.md`:
 
@@ -44,6 +44,8 @@ instructions below only cover this monorepo.
   [Corepack](https://nodejs.org/api/corepack.html) if you don't already)
 - For PHP work: PHP 8.2+ and Composer, plus `vendor/bin/phpunit` via
   `composer install` inside `src/php/core/`
+- For Python work: Python 3.10+ (CI runs on 3.10–3.14); install the package in a
+  virtualenv with `pip install -e ".[dev]"` inside `src/python/core/`
 
 ## Local setup
 
@@ -85,7 +87,8 @@ src/
 │   ├── core/          # Rendering engine (@dicebear/core)
 │   ├── cli/           # Command-line interface
 │   └── converter/     # SVG → raster converter
-└── php/             # PHP port (Composer package `dicebear/core`)
+├── php/             # PHP port (Composer package `dicebear/core`)
+└── python/          # Python port (PyPI package `dicebear-core`)
 apps/
 ├── docs/            # VitePress documentation site (dicebear.com), including the Playground
 └── editor/          # The in-browser editor (editor.dicebear.com)
@@ -119,21 +122,40 @@ composer install
 vendor/bin/phpunit
 ```
 
+### Python core (`src/python/core/`)
+
+```sh
+cd src/python/core
+pip install -e ".[dev]"   # in a virtualenv
+ruff check .
+ruff format --check .
+mypy src
+pytest
+```
+
+The Python core reads the two draft-07 schemas from the `dicebear-schema`
+package (the Python counterpart of `@dicebear/schema` / `dicebear/schema`), which
+`pip install -e ".[dev]"` pulls in as a runtime dependency — nothing is vendored.
+
 ### Cross-language parity
 
-`@dicebear/core` and `dicebear/core` (PHP) must produce **byte-identical**
-output for the same inputs. A shared fixture suite in `tests/fixtures/parity/`
-enforces this, and both sides consume it:
+`@dicebear/core` (JS), `dicebear/core` (PHP), and `dicebear-core` (Python) must
+produce **byte-identical** output for the same inputs. A shared fixture suite in
+`tests/fixtures/parity/` enforces this, and all three sides consume it:
 
 - JS side: `src/js/core/tests/Parity.test.js`, run via
   `npm run test --workspace @dicebear/core`.
 - PHP side: `tests/ParityTest.php`, run via `vendor/bin/phpunit` in
   `src/php/core/`.
+- Python side: `tests/test_parity.py`, run via `pytest` in `src/python/core/`.
 
 The fixtures cover `Fnv1a` (hash + hex), `Mulberry32` (chained sequences), every
-`Prng` method, and full `Avatar.toString()` output for the `initials`, `thumbs`,
-`glass`, and `notionists` styles. That last bucket covers seed, size,
-transforms, gradients, and component-variant overrides.
+`Prng` method, number-to-string formatting (`numbers.json` — the `formatNumber`
+contract: every emitted number rounded to at most 5 decimal places, which the
+JS, PHP, and Python helpers must reproduce identically), and full
+`Avatar.toString()` output for the `initials`, `thumbs`, `glass`, and
+`notionists` styles. That last bucket covers seed, size, transforms, gradients,
+and component-variant overrides.
 
 If your change affects rendering or the PRNG in `@dicebear/core`, regenerate the
 fixtures from the JS reference and commit the diff:
@@ -142,7 +164,8 @@ fixtures from the JS reference and commit the diff:
 npm run fixtures:parity
 ```
 
-The PHP suite will then fail loudly until the PHP side is brought back in sync.
+The PHP and Python suites will then fail loudly until those sides are brought
+back in sync.
 That is the intended signal. If you only intend to touch one language, expect to
 update both before your PR can be merged.
 
@@ -180,6 +203,9 @@ npm run build --workspace @dicebear/editor
 - TypeScript is `strict`. Prefer narrow types to `any` / `unknown` casts.
 - PHP code follows PSR-12; `vendor/bin/phpunit` and Composer's built-in scripts
   catch the rest.
+- Python code is formatted and linted with [Ruff](https://docs.astral.sh/ruff/)
+  and type-checked with `mypy` in strict mode; run `ruff check .`,
+  `ruff format .`, and `mypy src` in `src/python/core/` before you open a PR.
 
 ## Releasing (maintainers only)
 
@@ -198,8 +224,10 @@ or `10.2.0-alpha.1`). The script will:
 
 1. Update `version` in every `package.json` across the workspace
 2. Update internal workspace dependency references
-3. Sync `package-lock.json`
-4. Create a Git commit and tag (e.g. `v10.1.0`)
+3. Update `version` in `src/python/core/pyproject.toml` (the Python core is not
+   an npm workspace, so it is bumped explicitly to stay in lockstep)
+4. Sync `package-lock.json`
+5. Create a Git commit and tag (e.g. `v10.1.0`)
 
 Push the commit and the tag:
 
@@ -220,6 +248,16 @@ workflow, which:
      backporting a patch to `9.x` after `10.x` has shipped does not overwrite
      `latest`)
 4. Publishes all changed packages to npm via `scripts/publish.mjs`
+5. Builds `src/python/core` and publishes `dicebear-core` to PyPI via trusted
+   publishing (the `publish-python` job) — no token and no separate repository,
+   the same way the npm packages go out
+
+The PHP port is the exception: Composer/Packagist consumes one Git repository
+per package rather than a monorepo subdirectory, so `split-php-core.yml` mirrors
+`src/php/core` (tags included) to the standalone
+[`dicebear/dicebear-php`](https://github.com/dicebear/dicebear-php) repository,
+and Packagist publishes `dicebear/core` from that mirror. All three ports ride
+the same version the monorepo tagged.
 
 ## Licensing
 

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -37,6 +37,20 @@ for (const pkgPath of packageJsonPaths) {
   }
 }
 
+// The Python core is not an npm workspace (like the PHP core), so bump its
+// pyproject.toml here to keep all ports on the same version. Only the version
+// string is replaced so the rest of the manifest stays byte-for-byte untouched.
+const pyprojectPath = join(ROOT, "src/python/core/pyproject.toml");
+if (existsSync(pyprojectPath)) {
+  const raw = readFileSync(pyprojectPath, "utf-8");
+  const updated = raw.replace(/^version = "[^"]*"$/m, `version = "${version}"`);
+
+  if (updated !== raw) {
+    writeFileSync(pyprojectPath, updated);
+    console.log(`  dicebear-core (python): → ${version}`);
+  }
+}
+
 // Promote the changelog's Unreleased section to the new version
 const changelogPath = join(ROOT, "CHANGELOG.md");
 if (existsSync(changelogPath)) {

--- a/src/python/core/.gitignore
+++ b/src/python/core/.gitignore
@@ -1,0 +1,8 @@
+.venv
+dist
+dist-build
+*.egg-info
+__pycache__
+.pytest_cache
+.mypy_cache
+.ruff_cache

--- a/src/python/core/LICENSE
+++ b/src/python/core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Florian Körner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/python/core/README.md
+++ b/src/python/core/README.md
@@ -1,0 +1,72 @@
+# DiceBear Core (Python)
+
+Deterministic, customizable, vector-based avatars — the Python port of the
+DiceBear core engine. It produces **byte-identical** SVG output to the
+JavaScript (`@dicebear/core`) and PHP (`dicebear/core`) implementations for the
+same style definition and options.
+
+This package contains only the rendering engine. Avatar **style definitions**
+ship separately as language-agnostic JSON via
+[`dicebear-styles`](https://pypi.org/project/dicebear-styles/) (or any other
+source of a DiceBear style definition).
+
+## Installation
+
+```bash
+pip install dicebear-core
+```
+
+Requires Python 3.10 or newer.
+
+## Usage
+
+```python
+import json
+from importlib.resources import files
+
+from dicebear import Avatar
+
+# Load a style definition (here from the dicebear-styles package).
+style = json.loads(
+    files("dicebear_styles").joinpath("adventurer.json").read_text("utf-8")
+)
+
+avatar = Avatar(style, {"seed": "John"})
+
+avatar.to_string()    # the SVG markup
+avatar.to_data_uri()  # data:image/svg+xml;charset=utf-8,...
+avatar.to_json()      # {"svg": ..., "options": {...resolved options...}}
+```
+
+`Avatar` accepts either a raw style-definition dict or a `Style` instance, plus
+an optional options dict:
+
+```python
+from dicebear import Avatar, Style
+
+style = Style(style_data)
+Avatar(style, {"seed": "John", "size": 128, "backgroundColor": ["b6e3f4"]})
+```
+
+## Development
+
+This package lives in the
+[DiceBear monorepo](https://github.com/dicebear/dicebear) under
+`src/python/core`. See `CONTRIBUTING.md` in the repository root for the full
+workflow.
+
+```bash
+cd src/python/core
+pip install -e ".[dev]"
+ruff check .
+mypy src
+pytest
+```
+
+The decisive check is `tests/test_parity.py`, which asserts byte-identical
+output against the shared fixtures in `tests/fixtures/parity/` (generated from
+the JavaScript reference).
+
+## License
+
+[MIT](https://github.com/dicebear/dicebear/blob/10.x/src/python/core/LICENSE)

--- a/src/python/core/pyproject.toml
+++ b/src/python/core/pyproject.toml
@@ -1,0 +1,65 @@
+[build-system]
+# hatchling >= 1.27 is required for the PEP 639 `license = "MIT"` SPDX string.
+requires = ["hatchling>=1.27"]
+build-backend = "hatchling.build"
+
+[project]
+name = "dicebear-core"
+version = "10.0.1"
+description = "Unique avatars from dozens of styles — deterministic, customizable, vector-based."
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+license-files = ["LICENSE"]
+authors = [{ name = "Florian Körner", email = "contact@florian-koerner.com" }]
+keywords = ["dicebear", "avatar", "svg"]
+classifiers = [
+  "Intended Audience :: Developers",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Multimedia :: Graphics",
+]
+dependencies = ["jsonschema>=4.0", "dicebear-schema>=1.0.0"]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "mypy>=1.8", "ruff>=0.6"]
+
+[project.urls]
+Homepage = "https://www.dicebear.com"
+Repository = "https://github.com/dicebear/dicebear"
+Issues = "https://github.com/dicebear/dicebear/issues"
+
+# The package lives under src/dicebear. The JSON Schemas are not vendored: they
+# come from the `dicebear-schema` dependency and are read at runtime via
+# importlib.resources (files("dicebear_schema")), mirroring how the JS/PHP ports
+# pin @dicebear/schema / dicebear/schema.
+[tool.hatch.build.targets.wheel]
+packages = ["src/dicebear"]
+
+[tool.hatch.build.targets.sdist]
+include = ["src/dicebear", "tests", "README.md", "LICENSE", "pyproject.toml"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+
+[tool.mypy]
+python_version = "3.10"
+strict = true
+files = ["src"]
+
+# jsonschema ships no type stubs; the validator wraps it behind a typed boundary.
+[[tool.mypy.overrides]]
+module = ["jsonschema", "jsonschema.*"]
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/src/python/core/src/dicebear/__init__.py
+++ b/src/python/core/src/dicebear/__init__.py
@@ -1,0 +1,33 @@
+"""DiceBear core — deterministic, customizable, vector-based avatars.
+
+A faithful port of ``@dicebear/core`` (JS) and ``dicebear/core`` (PHP) that
+produces byte-identical SVG output for the same style and options.
+"""
+
+from __future__ import annotations
+
+from .avatar import Avatar
+from .errors import (
+    CircularColorReferenceError,
+    OptionsValidationError,
+    StyleValidationError,
+    ValidationError,
+)
+from .options_descriptor import OptionsDescriptor
+from .style import Style
+from .utils.color import Color
+
+# Public surface mirrors the JS index (Avatar, Style, Color, OptionsDescriptor)
+# plus the exception types Python consumers catch. Internals — Options, Prng,
+# Resolver, Renderer — remain importable from their submodules but are not
+# re-exported here.
+__all__ = [
+    "Avatar",
+    "CircularColorReferenceError",
+    "Color",
+    "OptionsDescriptor",
+    "OptionsValidationError",
+    "Style",
+    "StyleValidationError",
+    "ValidationError",
+]

--- a/src/python/core/src/dicebear/avatar.py
+++ b/src/python/core/src/dicebear/avatar.py
@@ -1,0 +1,52 @@
+"""Top-level entry point for rendering an avatar from a style and options."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+from urllib.parse import quote
+
+from .options import Options
+from .renderer import Renderer
+from .resolver import Resolver
+from .style import Style
+
+# encodeURIComponent leaves A-Za-z0-9 and -_.!~*'() unescaped. Python's quote
+# always keeps letters, digits, and _.-~; adding !*'() to ``safe`` reproduces
+# the JS set exactly (and drops the default '/' so it is escaped like JS does).
+_DATA_URI_SAFE = "!*'()"
+
+
+class Avatar:
+    """Top-level entry point for rendering an avatar from a style and options.
+
+    Construction immediately resolves and renders the SVG; the various accessor
+    methods return different serializations of that result.
+    """
+
+    def __init__(
+        self, style_input: Any, options_input: dict[str, Any] | None = None
+    ) -> None:
+        style = style_input if isinstance(style_input, Style) else Style(style_input)
+        options = Options(options_input)
+        resolver = Resolver(style, options)
+
+        self._svg = Renderer(style, resolver).render()
+        self._resolved_options = resolver.resolved()
+
+    def __str__(self) -> str:
+        return self._svg
+
+    def to_string(self) -> str:
+        """Return the rendered SVG markup."""
+        return self._svg
+
+    def to_json(self) -> dict[str, Any]:
+        """Return ``{"svg", "options"}`` — the SVG and the resolved options."""
+        return {"svg": self._svg, "options": copy.deepcopy(self._resolved_options)}
+
+    def to_data_uri(self) -> str:
+        """Return the SVG encoded as a ``data:image/svg+xml`` URI."""
+        return "data:image/svg+xml;charset=utf-8," + quote(
+            self._svg, safe=_DATA_URI_SAFE
+        )

--- a/src/python/core/src/dicebear/errors.py
+++ b/src/python/core/src/dicebear/errors.py
@@ -1,0 +1,66 @@
+"""Domain error types raised by the core."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class ErrorDetail(TypedDict, total=False):
+    """A single schema-validation failure."""
+
+    message: str
+    instancePath: str
+
+
+class ValidationError(RuntimeError):
+    """Base class for schema validation errors.
+
+    Carries the prefix in the exception message and the per-field failures in
+    :attr:`details`.
+    """
+
+    def __init__(self, prefix: str, details: list[ErrorDetail]) -> None:
+        parts: list[str] = []
+
+        for detail in details:
+            segments: list[str] = []
+
+            instance_path = detail.get("instancePath", "")
+            if instance_path != "":
+                segments.append(instance_path)
+
+            message = detail.get("message", "")
+            if message != "":
+                segments.append(message)
+
+            parts.append(" ".join(segments))
+
+        super().__init__(prefix + ": " + ", ".join(parts))
+        self.details = details
+
+
+class OptionsValidationError(ValidationError):
+    """Raised when avatar options fail schema validation."""
+
+    def __init__(self, details: list[ErrorDetail]) -> None:
+        super().__init__("Invalid options", details)
+
+
+class StyleValidationError(ValidationError):
+    """Raised when a style definition fails schema validation."""
+
+    def __init__(self, details: list[ErrorDetail]) -> None:
+        super().__init__("Invalid style definition", details)
+
+
+class CircularColorReferenceError(RuntimeError):
+    """Raised when a color references itself, directly or indirectly.
+
+    The :attr:`chain` field reproduces the resolution path.
+    """
+
+    def __init__(self, chain: list[str]) -> None:
+        path = " → ".join(chain)
+
+        super().__init__(f"Circular color reference: {path}")
+        self.chain = chain

--- a/src/python/core/src/dicebear/options.py
+++ b/src/python/core/src/dicebear/options.py
@@ -1,0 +1,138 @@
+"""User-supplied option parsing and normalization."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, cast
+
+from .validator import OptionsValidator
+
+Numeric = int | float
+Range = dict[str, Numeric]
+
+
+class Options:
+    """Validates raw user options and exposes them through typed accessors.
+
+    Each accessor returns the user's input in a normalized form (always a list
+    for options that accept either a scalar or a list, or ``None`` when the
+    option is not set), so consumers — chiefly :class:`Resolver` — never have to
+    do their own normalization.
+
+    Resolution against the style definition and the PRNG happens in
+    :class:`Resolver`; this class is purely about reading user input.
+    """
+
+    def __init__(self, data: dict[str, Any] | None = None) -> None:
+        data = data if data is not None else {}
+        OptionsValidator.validate(data)
+
+        # Deep-copy so later caller mutations cannot leak into resolution,
+        # mirroring the JS core's structuredClone and Style's deep copy.
+        self._data = copy.deepcopy(data)
+
+    def seed(self) -> str | None:
+        return cast("str | None", self._data.get("seed"))
+
+    def size(self) -> int | None:
+        return cast("int | None", self._data.get("size"))
+
+    def id_randomization(self) -> bool | None:
+        return cast("bool | None", self._data.get("idRandomization"))
+
+    def title(self) -> str | None:
+        return cast("str | None", self._data.get("title"))
+
+    def flip(self) -> list[str]:
+        return self._as_array(self._data.get("flip"))
+
+    def font_family(self) -> list[str]:
+        return self._as_array(self._data.get("fontFamily"))
+
+    def font_weight(self) -> list[Numeric]:
+        return self._as_array(self._data.get("fontWeight"))
+
+    def scale(self) -> Range | None:
+        return self._to_range(self._data.get("scale"))
+
+    def border_radius(self) -> Range | None:
+        return self._to_range(self._data.get("borderRadius"))
+
+    def rotate(self) -> Range | None:
+        return self._to_range(self._data.get("rotate"))
+
+    def translate_x(self) -> Range | None:
+        return self._to_range(self._data.get("translateX"))
+
+    def translate_y(self) -> Range | None:
+        return self._to_range(self._data.get("translateY"))
+
+    def component_variant(self, name: str) -> dict[str, Numeric] | None:
+        """Return the variant constraint for ``name`` as a weighted map, or
+        ``None`` when ``{name}Variant`` is unset.
+
+        A bare string or string list is normalized to a map weighted ``1`` each.
+        """
+        raw = self._data.get(name + "Variant")
+
+        if raw is None:
+            return None
+
+        if isinstance(raw, str):
+            return {raw: 1}
+
+        if isinstance(raw, list):
+            return dict.fromkeys(raw, 1)
+
+        return cast("dict[str, Numeric]", raw)
+
+    def component_probability(self, name: str) -> Numeric | None:
+        return cast("Numeric | None", self._data.get(name + "Probability"))
+
+    def color(self, name: str) -> list[str] | None:
+        """Return ``None`` (not ``[]``) when ``{name}Color`` is unset so the
+        resolver can fall back to the style definition's color values.
+        """
+        raw = self._data.get(name + "Color")
+
+        return None if raw is None else self._as_array(raw)
+
+    def color_fill(self, name: str) -> list[str]:
+        return self._as_array(self._data.get(name + "ColorFill"))
+
+    def color_angle(self, name: str) -> Range | None:
+        return self._to_range(self._data.get(name + "ColorAngle"))
+
+    def color_fill_stops(self, name: str) -> Range | None:
+        return self._to_range(self._data.get(name + "ColorFillStops"))
+
+    @staticmethod
+    def _as_array(value: Any) -> list[Any]:
+        if value is None:
+            return []
+
+        return value if isinstance(value, list) else [value]
+
+    @staticmethod
+    def _to_range(value: Any) -> Range | None:
+        """Normalize a range option (bare number, ``[n]``, ``[min, max]``, or
+        ``None``).
+
+        A bare number ``n`` — or a single-element array ``[n]`` — becomes
+        ``{'min': n, 'max': n}`` (a fixed value). An array's smaller/larger
+        element is taken as min/max. An empty array is treated as unset
+        (``None``), so the resolver applies the option's default.
+        """
+        if value is None:
+            return None
+
+        if isinstance(value, bool):
+            return None
+
+        if isinstance(value, (int, float)):
+            return {"min": value, "max": value}
+
+        if isinstance(value, list) and len(value) > 0:
+            return {"min": min(value), "max": max(value)}
+
+        return None

--- a/src/python/core/src/dicebear/options_descriptor.py
+++ b/src/python/core/src/dicebear/options_descriptor.py
@@ -1,0 +1,90 @@
+"""Builds a descriptor of every option a given style accepts."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from .style import Style
+
+_ROTATE_RANGE: dict[str, Any] = {"type": "range", "min": -360, "max": 360}
+_TRANSLATE_RANGE: dict[str, Any] = {"type": "range", "min": -1000, "max": 1000}
+
+
+class OptionsDescriptor:
+    """Builds a descriptor of every option a given style accepts.
+
+    Tooling such as the editor uses the result to render form controls and
+    validation hints without having to introspect the style itself.
+    """
+
+    def __init__(self, style: Style) -> None:
+        self._style = style
+        self._descriptor: dict[str, Any] | None = None
+
+    def to_json(self) -> dict[str, Any]:
+        """Return the descriptor, building it lazily on first call.
+
+        Each call returns an independent deep copy so callers can mutate the
+        result without affecting the cached descriptor.
+        """
+        if self._descriptor is None:
+            self._descriptor = self._build()
+
+        return copy.deepcopy(self._descriptor)
+
+    def _build(self) -> dict[str, Any]:
+        """Walk the style's components and colors and assemble the field map."""
+        result: dict[str, Any] = {
+            "seed": {"type": "string"},
+            "size": {"type": "number", "min": 1, "max": 4096},
+            "idRandomization": {"type": "boolean"},
+            "title": {"type": "string"},
+            "flip": {
+                "type": "enum",
+                "values": ["none", "horizontal", "vertical", "both"],
+                "list": True,
+            },
+            "fontFamily": {"type": "string", "list": True},
+            "fontWeight": {"type": "number", "min": 1, "max": 1000, "list": True},
+            "scale": {"type": "range", "min": 0, "max": 10},
+            "borderRadius": {"type": "range", "min": 0, "max": 50},
+            "rotate": dict(_ROTATE_RANGE),
+            "translateX": dict(_TRANSLATE_RANGE),
+            "translateY": dict(_TRANSLATE_RANGE),
+        }
+
+        for name, component in self._style.components().items():
+            if component.extends_name() is not None:
+                continue
+
+            variants = sorted(component.variants().keys())
+
+            result[f"{name}Variant"] = {
+                "type": "enum",
+                "values": variants,
+                "list": True,
+                "weighted": True,
+            }
+            result[f"{name}Probability"] = {"type": "number", "min": 0, "max": 100}
+
+        colors = self._style.colors()
+        color_names = [*colors.keys(), "background"]
+
+        for name in color_names:
+            color_field: dict[str, Any] = {"type": "color", "list": True}
+            contrast_to = colors[name].contrast_to() if name in colors else None
+
+            if contrast_to is not None:
+                color_field["contrastTo"] = contrast_to
+
+            result[f"{name}Color"] = color_field
+            result[f"{name}ColorFill"] = {
+                "type": "enum",
+                "values": ["solid", "linear", "radial"],
+                "list": True,
+            }
+            result[f"{name}ColorFillStops"] = {"type": "range", "min": 2}
+            result[f"{name}ColorAngle"] = dict(_ROTATE_RANGE)
+
+        return result

--- a/src/python/core/src/dicebear/prng/__init__.py
+++ b/src/python/core/src/dicebear/prng/__init__.py
@@ -1,0 +1,186 @@
+"""Key-based pseudorandom number generator and its primitives."""
+
+from __future__ import annotations
+
+import builtins
+import math
+from collections.abc import Callable, Sequence
+from typing import TypeVar
+
+from ..utils.number import Number
+from .fnv1a import Fnv1a
+from .mulberry32 import Mulberry32
+
+__all__ = ["Fnv1a", "Mulberry32", "Prng"]
+
+T = TypeVar("T")
+
+# The bool() / float() methods below shadow the builtins for the class scope, so
+# signature annotations that need the builtin types reference them via builtins.
+_Float = builtins.float
+_Bool = builtins.bool
+
+Numeric = int | float
+Range = dict[str, Numeric]
+
+
+class Prng:
+    """Key-based pseudorandom number generator.
+
+    Each method takes a key that, combined with the seed, produces a
+    deterministic value. The same seed + key always yields the same result,
+    regardless of call order.
+    """
+
+    def __init__(self, seed: str) -> None:
+        self._seed = seed
+
+    def pick(self, key: str, items: Sequence[T]) -> T | None:
+        """Pick a single item from ``items`` deterministically.
+
+        Returns ``None`` for an empty list. Duplicate values (by string
+        representation) are collapsed before picking so that input order and
+        duplication do not affect the result.
+        """
+        if len(items) == 0:
+            return None
+
+        if len(items) == 1:
+            return items[0]
+
+        unique = _unique_by_code_point(items)
+
+        if len(unique) == 1:
+            return unique[0]
+
+        ordered = sorted(unique, key=_code_point_key)
+        index = math.floor(self.get_value(key) * len(ordered))
+
+        return ordered[index]
+
+    def weighted_pick(self, key: str, weights: dict[str, Numeric]) -> str | None:
+        """Pick a key from ``weights`` proportional to its weight.
+
+        When all weights are zero, falls back to an unweighted :meth:`pick`.
+        Returns ``None`` for an empty map.
+        """
+        if len(weights) == 0:
+            return None
+
+        keys = list(weights.keys())
+
+        if len(keys) == 1:
+            return str(keys[0])
+
+        keys = sorted(keys, key=_code_point_key)
+
+        # Sum in sorted-key order to match JS reduce-over-sorted parity — float
+        # addition is non-associative, so iterating in insertion order would
+        # diverge from JS for fractional weights.
+        total_weight: float = 0.0
+        for k in keys:
+            total_weight += weights[k]
+
+        if total_weight == 0.0:
+            return self.pick(key, [str(k) for k in keys])
+
+        threshold = self.get_value(key) * total_weight
+        cumulative: float = 0
+
+        for k in keys:
+            cumulative += weights[k]
+
+            if threshold < cumulative:
+                return str(k)
+
+        return str(keys[-1])
+
+    def bool(self, key: str, likelihood: _Float = 50) -> _Bool:
+        """Return ``True`` with the given probability (0–100, default 50)."""
+        return self.get_value(key) * 100 < likelihood
+
+    def float(self, key: str, range: Range) -> _Float:
+        """Return a deterministic float in ``range``, rounded to four decimals.
+
+        With ``range['step'] > 0``, the result is drawn uniformly from
+        ``{ min + i*step | 0 <= i <= floor((max - min) / step) }``, so both
+        endpoints of an evenly-divisible range are equally likely. Non-positive
+        or absent step means continuous. ``min``/``max`` are sorted internally,
+        so a reversed pair is tolerated.
+        """
+        low = min(range["min"], range["max"])
+        high = max(range["min"], range["max"])
+        step = range.get("step", 0)
+
+        if step > 0:
+            buckets = math.floor((high - low) / step) + 1
+            i = math.floor(self.get_value(key) * buckets)
+            value = low + i * step
+        else:
+            value = low + self.get_value(key) * (high - low)
+
+        return Number.round_half_up(value * 10000) / 10000
+
+    def integer(self, key: str, range: Range) -> int:
+        """Return a deterministic integer in ``range``.
+
+        ``min``/``max`` are sorted internally, so a reversed pair is tolerated.
+        ``range['step']`` is accepted for symmetry with :meth:`float` but ignored.
+        """
+        low = int(min(range["min"], range["max"]))
+        high = int(max(range["min"], range["max"]))
+
+        return math.floor(self.get_value(key) * (high - low + 1)) + low
+
+    def shuffle(self, key: str, items: Sequence[T]) -> list[T]:
+        """Fisher-Yates shuffle with chained Mulberry32 state.
+
+        Duplicate values (by string representation) are collapsed before
+        shuffling, so a caller's slice off the front cannot accidentally produce
+        a repeated value.
+        """
+        if len(items) <= 1:
+            return list(items)
+
+        result = sorted(_unique_by_code_point(items), key=_code_point_key)
+        prng = Mulberry32(Fnv1a.hash(self._seed + ":" + key))
+
+        for i in range(len(result) - 1, 0, -1):
+            j = math.floor(prng.next_float() * (i + 1))
+            result[i], result[j] = result[j], result[i]
+
+        return result
+
+    def get_value(self, key: str) -> _Float:
+        """Return a single float in ``[0, 1)`` derived from ``seed:key``.
+
+        The same seed/key pair always produces the same value.
+        """
+        return Mulberry32(Fnv1a.hash(self._seed + ":" + key)).next_float()
+
+
+def _code_point_key(value: object) -> str:
+    """Cross-language deterministic sort key.
+
+    Compare by the string representation's code points, matching JS
+    ``String(a) < String(b)`` and PHP ``strcmp`` for the ASCII values sorted in
+    practice (variant names, hex colors).
+    """
+    return str(value)
+
+
+def _unique_by_code_point(
+    items: Sequence[T], key_fn: Callable[[T], str] = str
+) -> list[T]:
+    """Deduplicate by string representation, keeping the first occurrence."""
+    seen: set[str] = set()
+    result: list[T] = []
+
+    for item in items:
+        repr_ = key_fn(item)
+
+        if repr_ not in seen:
+            seen.add(repr_)
+            result.append(item)
+
+    return result

--- a/src/python/core/src/dicebear/prng/fnv1a.py
+++ b/src/python/core/src/dicebear/prng/fnv1a.py
@@ -1,0 +1,47 @@
+"""FNV-1a 32-bit hash."""
+
+from __future__ import annotations
+
+import struct
+
+
+class Fnv1a:
+    """FNV-1a 32-bit hash.
+
+    Offset basis: ``0x811c9dc5``, prime: ``0x01000193``.
+
+    See https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+    """
+
+    @staticmethod
+    def hash(value: str) -> int:
+        """Return the unsigned 32-bit FNV-1a hash of ``value``.
+
+        The input is decomposed into UTF-16 code units before hashing so the
+        result is identical across language ports.
+        """
+        result = 0x811C9DC5
+
+        for code in _utf16_code_units(value):
+            result = ((result ^ code) * 0x01000193) & 0xFFFFFFFF
+
+        return result
+
+    @staticmethod
+    def hex(value: str) -> str:
+        """Return the FNV-1a hash of ``value`` as an 8-char lowercase hex string."""
+        return format(Fnv1a.hash(value), "08x")
+
+
+def _utf16_code_units(value: str) -> list[int]:
+    """Convert a string to its UTF-16 code units, matching JS ``charCodeAt``.
+
+    Iterating ``value`` directly would yield code points and break on non-BMP
+    input (e.g. emoji), so encode to little-endian UTF-16 and read uint16 units.
+    """
+    if value == "":
+        return []
+
+    encoded = value.encode("utf-16-le")
+
+    return list(struct.unpack(f"<{len(encoded) // 2}H", encoded))

--- a/src/python/core/src/dicebear/prng/mulberry32.py
+++ b/src/python/core/src/dicebear/prng/mulberry32.py
@@ -1,0 +1,57 @@
+"""Mulberry32 PRNG."""
+
+from __future__ import annotations
+
+_UINT32_MAX_PLUS_1 = 2**32
+
+
+class Mulberry32:
+    """Mulberry32 PRNG — stateful, matching the C reference by Tommy Ettinger.
+
+    C original::
+
+        uint32_t z = (x += 0x6D2B79F5UL);
+        z = (z ^ (z >> 15)) * (z | 1UL);
+        z ^= z + (z ^ (z >> 7)) * (z | 61UL);
+        return z ^ (z >> 14);
+
+    All arithmetic is unsigned 32-bit. Python ints are arbitrary precision, so
+    every operation is masked with ``& 0xFFFFFFFF`` to emulate JS ``Math.imul``
+    / ``>>>`` and keep parity with the JS reference.
+
+    See https://gist.github.com/tommyettinger/46a874533244883189143505d203312c
+    """
+
+    def __init__(self, seed: int = 0) -> None:
+        self._state = seed & 0xFFFFFFFF
+
+    def next(self) -> int:
+        """Advance the state and return the next unsigned 32-bit value."""
+        z = (self._state + 0x6D2B79F5) & 0xFFFFFFFF
+        self._state = z
+
+        z = _mul(z ^ (z >> 15), z | 1)
+        z ^= _add(z, _mul(z ^ (z >> 7), z | 61))
+
+        return (z ^ (z >> 14)) & 0xFFFFFFFF
+
+    def next_float(self) -> float:
+        """Advance the state and return the next value in ``[0, 1)``."""
+        return self.next() / _UINT32_MAX_PLUS_1
+
+    def state(self) -> int:
+        """Return the current state as a signed 32-bit value (for JS compat)."""
+        if self._state >= 0x80000000:
+            return self._state - _UINT32_MAX_PLUS_1
+
+        return self._state
+
+
+def _mul(a: int, b: int) -> int:
+    """Unsigned 32-bit multiply (low 32 bits), matching JS ``Math.imul``."""
+    return (a * b) & 0xFFFFFFFF
+
+
+def _add(a: int, b: int) -> int:
+    """Unsigned 32-bit add."""
+    return (a + b) & 0xFFFFFFFF

--- a/src/python/core/src/dicebear/renderer.py
+++ b/src/python/core/src/dicebear/renderer.py
@@ -1,0 +1,487 @@
+"""Walks a style's element tree and turns it into the final SVG markup."""
+
+from __future__ import annotations
+
+import random
+import re
+from typing import Any
+
+from .prng import Fnv1a
+from .resolver import Resolver
+from .style import Style
+from .style_def.canvas import Canvas
+from .style_def.component import Component
+from .style_def.element import Element
+from .utils.initials import Initials
+from .utils.license import License
+from .utils.number import Number
+from .utils.xml import Xml
+
+_ID_PATTERN = re.compile(r'\bid="([^"]+)"')
+
+
+class Renderer:
+    """Walks a style's element tree and turns it into the final SVG markup.
+
+    The renderer is single-use: it accumulates ``<defs>`` entries and per-render
+    caches across method calls, so a fresh instance is required per avatar.
+    """
+
+    def __init__(self, style: Style, resolver: Resolver) -> None:
+        self._style = style
+        self._resolver = resolver
+        self._defs: dict[str, str] = {}
+        self._cached_seed_hash: str | None = None
+        self._cached_initials: str | None = None
+
+    def render(self) -> str:
+        """Build the complete SVG document for the avatar."""
+        canvas = self._style.canvas()
+        background = self._render_background(canvas)
+        body = self._render_elements(canvas.elements())
+
+        # Order matters: scale and flip around center, then rotate, translate,
+        # and finally clip with border radius (outermost wrapper).
+        body = self._apply_scale(body, canvas)
+        body = self._apply_flip(body, canvas)
+        body = self._apply_rotate(body, canvas)
+        body = self._apply_translate(body, canvas)
+        body = self._apply_border_radius(background + body, canvas)
+
+        metadata = License.xml(self._style.meta())
+        defs = "<defs>" + "".join(self._defs.values()) + "</defs>" if self._defs else ""
+        size = self._resolver.size()
+
+        title = self._resolver.title()
+        escaped_title = Xml.escape(title) if title is not None else None
+
+        width = Number.format(canvas.width())
+        height = Number.format(canvas.height())
+        attrs = [
+            'xmlns="http://www.w3.org/2000/svg"',
+            f'viewBox="0 0 {width} {height}"',
+        ]
+
+        root_attributes = self._render_attributes(self._style.attributes())
+
+        if root_attributes != "":
+            attrs.append(root_attributes.lstrip())
+
+        if escaped_title is not None:
+            attrs.append('role="img"')
+            attrs.append(f'aria-label="{escaped_title}"')
+        else:
+            attrs.append('aria-hidden="true"')
+
+        if size is not None:
+            attrs.append(f'width="{Number.format(size)}"')
+            attrs.append(f'height="{Number.format(size)}"')
+
+        title_element = (
+            f"<title>{escaped_title}</title>" if escaped_title is not None else ""
+        )
+
+        svg = (
+            "<svg "
+            + " ".join(attrs)
+            + ">"
+            + metadata
+            + defs
+            + title_element
+            + body
+            + "</svg>"
+        )
+
+        if self._resolver.id_randomization():
+            svg = self._randomize_ids(svg)
+
+        return svg
+
+    def _apply_flip(self, body: str, canvas: Canvas) -> str:
+        """Wrap ``body`` in a flip transform when ``flip`` is not ``'none'``."""
+        flip = self._resolver.flip()
+
+        if flip == "none":
+            return body
+
+        w = Number.format(canvas.width())
+        h = Number.format(canvas.height())
+
+        transform = {
+            "horizontal": f"translate({w}, 0) scale(-1, 1)",
+            "vertical": f"translate(0, {h}) scale(1, -1)",
+            "both": f"translate({w}, {h}) scale(-1, -1)",
+        }[flip]
+
+        return f'<g transform="{transform}">{body}</g>'
+
+    def _apply_scale(self, body: str, canvas: Canvas) -> str:
+        """Wrap ``body`` in a uniform scale around center when scale != 1."""
+        scale = self._resolver.scale()
+
+        if scale == 1:
+            return body
+
+        cx = canvas.width() / 2
+        cy = canvas.height() / 2
+        cx_value = Number.format(cx)
+        cy_value = Number.format(cy)
+        scale_value = Number.format(scale)
+        neg_cx = Number.format(-cx)
+        neg_cy = Number.format(-cy)
+
+        return (
+            f'<g transform="translate({cx_value}, {cy_value}) '
+            f"scale({scale_value}) "
+            f'translate({neg_cx}, {neg_cy})">{body}</g>'
+        )
+
+    def _apply_border_radius(self, body: str, canvas: Canvas) -> str:
+        """Clip ``body`` to the (rounded) canvas rectangle via a ``clipPath``.
+
+        The clip is always applied so transformed content cannot bleed past the
+        canvas bounds, regardless of the consumer's overflow setting.
+        """
+        radius = self._resolver.border_radius()
+        id_ = "clip-" + self._hash_seed()
+
+        rx = Number.format((radius / 100) * canvas.width())
+        ry = Number.format((radius / 100) * canvas.height())
+        width = Number.format(canvas.width())
+        height = Number.format(canvas.height())
+
+        self._defs[id_] = (
+            f'<clipPath id="{id_}"><rect width="{width}" height="{height}" '
+            f'rx="{rx}" ry="{ry}"/></clipPath>'
+        )
+
+        return f'<g clip-path="url(#{id_})">{body}</g>'
+
+    def _apply_rotate(self, body: str, canvas: Canvas) -> str:
+        """Wrap ``body`` in a rotation around center when ``rotate`` is non-zero."""
+        rotate = self._resolver.rotate()
+
+        if rotate == 0:
+            return body
+
+        cx = Number.format(canvas.width() / 2)
+        cy = Number.format(canvas.height() / 2)
+        rotate_value = Number.format(rotate)
+
+        return f'<g transform="rotate({rotate_value}, {cx}, {cy})">{body}</g>'
+
+    def _apply_translate(self, body: str, canvas: Canvas) -> str:
+        """Wrap ``body`` in a translate when translateX/translateY is non-zero.
+
+        Offsets are interpreted as percentages of the canvas dimensions.
+        """
+        tx = self._resolver.translate_x()
+        ty = self._resolver.translate_y()
+
+        if tx == 0 and ty == 0:
+            return body
+
+        x = Number.format((tx / 100) * canvas.width())
+        y = Number.format((ty / 100) * canvas.height())
+
+        return f'<g transform="translate({x}, {y})">{body}</g>'
+
+    def _render_background(self, canvas: Canvas) -> str:
+        """Return a ``<rect>`` with the resolved background color, or ``''``."""
+        colors = self._resolver.color("background")
+
+        if len(colors) == 0:
+            return ""
+
+        fill = Xml.escape(self._resolve_color_reference("background"))
+        width = Number.format(canvas.width())
+        height = Number.format(canvas.height())
+
+        return f'<rect width="{width}" height="{height}" fill="{fill}"/>'
+
+    def _randomize_ids(self, svg: str) -> str:
+        """Suffix every ``id`` declaration and reference with a random hex string.
+
+        Uses ``random`` intentionally — a PRNG-derived suffix would produce the
+        same ID for the same seed.
+        """
+        suffix = format(random.randint(0, 0xFFFFFF), "06x")
+
+        ids = list(dict.fromkeys(_ID_PATTERN.findall(svg)))
+
+        if len(ids) == 0:
+            return svg
+
+        escaped = [re.escape(i) for i in ids]
+        pattern = re.compile(r'(id="|url\(#|href="#)(' + "|".join(escaped) + r')("|\))')
+
+        return pattern.sub(
+            lambda m: m.group(1) + m.group(2) + "-" + suffix + m.group(3), svg
+        )
+
+    def _render_elements(self, elements: list[Element]) -> str:
+        """Render a list of elements and concatenate their markup."""
+        return "".join(self._render_element(el) for el in elements)
+
+    def _render_element(self, element: Element) -> str:
+        """Dispatch a single element to the renderer for its type."""
+        element_type = element.type()
+
+        if element_type == "element":
+            return self._render_svg_element(element)
+
+        if element_type == "text":
+            return self._render_text_element(element)
+
+        if element_type == "component":
+            return self._render_component_element(element)
+
+        return ""
+
+    def _render_svg_element(self, element: Element) -> str:
+        """Render an SVG element; the special ``defs`` name diverts children.
+
+        Element and attribute names are not escaped here — they are validated by
+        StyleValidator against a strict allowlist schema. Values are escaped via
+        :meth:`Xml.escape`.
+        """
+        name = element.name()
+
+        if name is None:
+            return ""
+
+        if name == "defs":
+            for child in element.children():
+                rendered = self._render_element(child)
+
+                if len(rendered) > 0:
+                    attrs = child.attributes()
+                    child_id = attrs.get("id") if attrs is not None else None
+                    key = (
+                        child_id
+                        if isinstance(child_id, str)
+                        else "_" + str(len(self._defs))
+                    )
+                    self._defs[key] = rendered
+
+            return ""
+
+        attrs_str = self._render_attributes(element.attributes())
+        children = self._render_elements(element.children())
+
+        if len(children) == 0:
+            return f"<{name}{attrs_str}/>"
+
+        return f"<{name}{attrs_str}>{children}</{name}>"
+
+    def _render_text_element(self, element: Element) -> str:
+        """Render a text element by escaping its resolved value."""
+        value = element.value()
+
+        return Xml.escape(self._resolve_value(value)) if value is not None else ""
+
+    def _render_component_element(self, element: Element) -> str:
+        """Resolve a component reference to a variant and emit a ``<use>``.
+
+        Aliases of the same source component sharing a variant — and identical
+        components referenced more than once — produce a single ``<defs>`` entry
+        referenced by every ``<use>``. A user-supplied ``transform`` is prepended
+        to the per-component transforms.
+        """
+        component_name = element.name()
+
+        if not isinstance(component_name, str):
+            return ""
+
+        variant_name = self._resolver.variant(component_name)
+
+        if variant_name is None:
+            return ""
+
+        component = self._style.components().get(component_name)
+
+        if component is None:
+            return ""
+
+        variant = component.variants().get(variant_name)
+
+        if variant is None:
+            return ""
+
+        id_ = f"{component.source_name()}-{variant_name}-{self._hash_seed()}"
+
+        if id_ not in self._defs:
+            body = self._render_elements(variant.elements())
+            self._defs[id_] = f'<g id="{id_}">{body}</g>'
+
+        transforms = self._build_transforms(component)
+        user_attributes = element.attributes()
+        merged_attributes: dict[str, Any] | None = user_attributes
+
+        if len(transforms) > 0:
+            user_transform = (
+                user_attributes.get("transform") if user_attributes else None
+            )
+            if isinstance(user_transform, str) and user_transform != "":
+                all_parts = [user_transform, *transforms]
+            else:
+                all_parts = transforms
+
+            merged_attributes = {
+                **(user_attributes or {}),
+                "transform": " ".join(all_parts),
+            }
+
+        attrs_str = self._render_attributes(merged_attributes)
+
+        return f'<use{attrs_str} href="#{id_}"/>'
+
+    def _build_transforms(self, component: Component) -> list[str]:
+        """Return the per-component SVG ``transform`` fragments.
+
+        Ordered so that, joined into one ``transform`` attribute, the scale is
+        the rightmost (innermost) transform — applied first, then rotate, then
+        translate.
+        """
+        t = self._resolver.component_transform(component.name())
+        rotate = t["rotate"]
+        translate_x = t["translateX"]
+        translate_y = t["translateY"]
+        scale = t["scale"]
+
+        if translate_x == 0 and translate_y == 0 and rotate == 0 and scale == 1:
+            return []
+
+        transforms: list[str] = []
+        cx = component.width() / 2
+        cy = component.height() / 2
+        cx_value = Number.format(cx)
+        cy_value = Number.format(cy)
+
+        if translate_x != 0 or translate_y != 0:
+            x = Number.format((translate_x / 100) * component.width())
+            y = Number.format((translate_y / 100) * component.height())
+            transforms.append(f"translate({x}, {y})")
+
+        if rotate != 0:
+            rotate_value = Number.format(rotate)
+            transforms.append(f"rotate({rotate_value}, {cx_value}, {cy_value})")
+
+        if scale != 1:
+            scale_value = Number.format(scale)
+            neg_cx = Number.format(-cx)
+            neg_cy = Number.format(-cy)
+            transforms.append(
+                f"translate({cx_value}, {cy_value}) scale({scale_value}) "
+                f"translate({neg_cx}, {neg_cy})"
+            )
+
+        return transforms
+
+    def _render_attributes(self, attributes: dict[str, Any] | None) -> str:
+        """Serialize an attribute map to a leading space-prefixed string."""
+        if attributes is None:
+            return ""
+
+        parts: list[str] = []
+
+        for key, value in attributes.items():
+            if value is None:
+                continue
+
+            parts.append(
+                f'{key}="' + Xml.escape(self._resolve_attribute_value(value)) + '"'
+            )
+
+        if len(parts) == 0:
+            return ""
+
+        return " " + " ".join(parts)
+
+    def _resolve_attribute_value(self, value: str | dict[str, Any]) -> str:
+        """Resolve a single attribute value: literals pass through; references
+        are dereferenced through the option resolver.
+        """
+        if isinstance(value, str):
+            return value
+
+        if value.get("type") == "color":
+            return self._resolve_color_reference(value["name"])
+
+        return self._resolve_variable(value["name"])
+
+    def _resolve_color_reference(self, name: str) -> str:
+        """Resolve a named color into a hex string or a ``url(#…)`` gradient."""
+        colors = self._resolver.color(name)
+        fill = self._resolver.color_fill(name)
+
+        if fill == "solid" or len(colors) <= 1:
+            return colors[0] if len(colors) > 0 else "none"
+
+        return self._build_gradient_def(name, colors, fill)
+
+    def _build_gradient_def(self, name: str, colors: list[str], fill: str) -> str:
+        """Build the linear/radial gradient, register it, return its reference."""
+        rotation = self._resolver.color_angle(name)
+        id_ = f"{name}-color-{self._hash_seed()}"
+        tag = "linearGradient" if fill == "linear" else "radialGradient"
+        rotate_attr = (
+            f' gradientTransform="rotate({Number.format(rotation)}, 0.5, 0.5)"'
+            if rotation != 0
+            else ""
+        )
+
+        stops: list[str] = []
+        count = len(colors)
+
+        for i, color in enumerate(colors):
+            offset = Number.format(i / (count - 1) * 100)
+            stops.append(
+                f'<stop offset="{offset}%" stop-color="' + Xml.escape(color) + '"/>'
+            )
+
+        self._defs[id_] = (
+            f'<{tag} id="{id_}"{rotate_attr}>' + "".join(stops) + f"</{tag}>"
+        )
+
+        return f"url(#{id_})"
+
+    def _resolve_value(self, value: str | dict[str, Any]) -> str:
+        """Resolve an element value: literals pass through; variables resolved."""
+        if isinstance(value, str):
+            return value
+
+        if value.get("type") == "variable":
+            return self._resolve_variable(value["name"])
+
+        return ""
+
+    def _resolve_variable(self, name: str) -> str:
+        """Resolve a built-in variable reference to its current value."""
+        if name == "initial":
+            return self._initials()[0:1]
+
+        if name == "initials":
+            return self._initials()
+
+        if name == "fontWeight":
+            return Number.format(self._resolver.font_weight())
+
+        if name == "fontFamily":
+            return self._resolver.font_family()
+
+        return ""
+
+    def _initials(self) -> str:
+        """Return the seed-derived initials, cached after the first call."""
+        if self._cached_initials is None:
+            self._cached_initials = Initials.from_seed(self._resolver.seed())
+
+        return self._cached_initials
+
+    def _hash_seed(self) -> str:
+        """Return the FNV-1a hex hash of the seed, cached after the first call."""
+        if self._cached_seed_hash is None:
+            self._cached_seed_hash = Fnv1a.hex(self._resolver.seed())
+
+        return self._cached_seed_hash

--- a/src/python/core/src/dicebear/resolver.py
+++ b/src/python/core/src/dicebear/resolver.py
@@ -1,0 +1,259 @@
+"""Deterministic resolution of options against a style, with memoization."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, TypeVar, cast
+
+from .errors import CircularColorReferenceError
+from .options import Options, Range
+from .prng import Prng
+from .style import Style
+from .style_def.component import Component
+from .utils.color import Color as ColorUtil
+
+T = TypeVar("T")
+
+
+class Resolver:
+    """Bundles the :class:`Style`, validated :class:`Options`, and a seeded
+    :class:`Prng`, exposing them as memoized named accessors.
+
+    The memo also serves as the informational snapshot returned by
+    :meth:`resolved` — every value the resolver picks during one resolution
+    lands there, except for the raw seed.
+    """
+
+    def __init__(self, style: Style, options: Options) -> None:
+        self._style = style
+        self._options = options
+        self._prng = Prng(self.seed())
+        self._color_resolving: list[str] = []
+        self._result: dict[str, Any] = {}
+
+    def seed(self) -> str:
+        # Deliberately not memoized — the seed is the only input kept out of the
+        # resolved() snapshot, so a serialized avatar never leaks it.
+        return self._options.seed() or ""
+
+    def size(self) -> int | None:
+        return self._memo("size", self._options.size)
+
+    def id_randomization(self) -> bool:
+        return self._memo(
+            "idRandomization", lambda: self._options.id_randomization() or False
+        )
+
+    def title(self) -> str | None:
+        return self._memo("title", self._options.title)
+
+    def flip(self) -> str:
+        return self._memo(
+            "flip", lambda: self._prng.pick("flip", self._options.flip()) or "none"
+        )
+
+    def font_family(self) -> str:
+        return self._memo(
+            "fontFamily",
+            lambda: (
+                self._prng.pick("fontFamily", self._options.font_family())
+                or "system-ui"
+            ),
+        )
+
+    def font_weight(self) -> int | float:
+        return self._memo(
+            "fontWeight",
+            lambda: self._prng.pick("fontWeight", self._options.font_weight()) or 400,
+        )
+
+    def scale(self) -> float:
+        return self._memo_float("scale", self._options.scale(), 1.0)
+
+    def border_radius(self) -> float:
+        return self._memo_float("borderRadius", self._options.border_radius(), 0.0)
+
+    def rotate(self) -> float:
+        return self._memo_float("rotate", self._options.rotate(), 0.0)
+
+    def translate_x(self) -> float:
+        return self._memo_float("translateX", self._options.translate_x(), 0.0)
+
+    def translate_y(self) -> float:
+        return self._memo_float("translateY", self._options.translate_y(), 0.0)
+
+    def variant(self, name: str) -> str | None:
+        """Select a variant for the given component.
+
+        With ``{name}Variant`` unset the PRNG picks from all style variants by
+        weight; otherwise it picks using the user-supplied weighted map. Only
+        variants that exist in the style definition are considered.
+        """
+        return self._memo(f"{name}Variant", lambda: self._resolve_variant(name))
+
+    def _resolve_variant(self, name: str) -> str | None:
+        component = self._style.components().get(name)
+
+        if component is None or not self._is_visible(name, component):
+            return None
+
+        raw = self._options.component_variant(component.source_name())
+        variants = component.variants()
+        weights: dict[str, int | float] = {}
+
+        if raw is None:
+            for v, variant in variants.items():
+                weights[v] = variant.weight()
+        else:
+            for v, weight in raw.items():
+                if v in variants:
+                    weights[v] = weight
+
+        return self._prng.weighted_pick(f"{name}Variant", weights)
+
+    def color(self, name: str) -> list[str]:
+        return self._memo(f"{name}Color", lambda: self._resolve_color(name))
+
+    def color_fill(self, name: str) -> str:
+        return self._memo(
+            f"{name}ColorFill",
+            lambda: (
+                self._prng.pick(f"{name}ColorFill", self._options.color_fill(name))
+                or "solid"
+            ),
+        )
+
+    def color_angle(self, name: str) -> float:
+        return self._memo_float(
+            f"{name}ColorAngle", self._options.color_angle(name), 0.0
+        )
+
+    def component_transform(self, name: str) -> dict[str, float]:
+        """Pick the rotate/translateX/translateY/scale values for a component.
+
+        Memoized per ``name``, so the four values land in :meth:`resolved` as
+        ``{name}Rotate`` / ``{name}TranslateX`` / ``{name}TranslateY`` /
+        ``{name}Scale`` for downstream introspection.
+        """
+        component = self._style.components().get(name)
+
+        return {
+            "rotate": self._memo_float(
+                f"{name}Rotate",
+                component.rotate() if component is not None else None,
+                0.0,
+            ),
+            "translateX": self._memo_float(
+                f"{name}TranslateX",
+                component.translate().x() if component is not None else None,
+                0.0,
+            ),
+            "translateY": self._memo_float(
+                f"{name}TranslateY",
+                component.translate().y() if component is not None else None,
+                0.0,
+            ),
+            "scale": self._memo_float(
+                f"{name}Scale",
+                component.scale() if component is not None else None,
+                1.0,
+            ),
+        }
+
+    def resolved(self) -> dict[str, Any]:
+        """Return an informational snapshot of every value the resolver picked.
+
+        Unset entries (``None``) are filtered out so they disappear on JSON
+        encode, mirroring the JS behavior. The raw seed is excluded.
+        """
+        return {k: v for k, v in self._result.items() if v is not None}
+
+    def _probability(self, component: Component) -> int | float:
+        """Return the visibility probability (0–100) for the component.
+
+        Aliases read the source component's user-set probability so a single
+        ``{source}Probability`` option propagates to every alias of the source.
+        """
+        raw = self._options.component_probability(component.source_name())
+
+        return raw if raw is not None else component.probability()
+
+    def _is_visible(self, name: str, component: Component) -> bool:
+        return self._prng.bool(f"{name}Probability", self._probability(component))
+
+    def _resolve_color(self, name: str) -> list[str]:
+        """Resolve a named color to its final stop list, applying contrast
+        sorting and ``notEqualTo`` filtering from the style definition.
+        """
+        user_colors = self._options.color(name)
+        style_color = self._style.colors().get(name)
+
+        if user_colors is not None:
+            source = user_colors
+        elif style_color is not None:
+            source = style_color.values()
+        else:
+            source = []
+
+        candidates = [ColorUtil.to_hex(c) for c in source]
+        fill = self.color_fill(name)
+        stops = 1 if fill == "solid" else self._color_fill_stops(name)
+
+        if style_color is None:
+            return self._prng.shuffle(f"{name}Color", candidates)[:stops]
+
+        # Detect circular references (e.g. a.contrastTo = b, b.contrastTo = a).
+        if name in self._color_resolving:
+            raise CircularColorReferenceError([*self._color_resolving, name])
+
+        self._color_resolving.append(name)
+        contrast_to = style_color.contrast_to()
+        not_equal_to = style_color.not_equal_to()
+
+        try:
+            if contrast_to is not None:
+                ref = self.color(contrast_to)
+                ref_color = ref[0] if len(ref) > 0 else None
+
+                if ref_color is not None:
+                    candidates = ColorUtil.sort_by_contrast(candidates, ref_color)
+
+            if len(not_equal_to) > 0:
+                excluded: list[str] = []
+
+                for ref_name in not_equal_to:
+                    excluded.extend(self.color(ref_name))
+
+                candidates = ColorUtil.filter_not_equal_to(candidates, excluded)
+        finally:
+            self._color_resolving.pop()
+
+        # Skip shuffle when sorted by contrast to preserve the ordering.
+        ordered = (
+            candidates
+            if contrast_to is not None
+            else self._prng.shuffle(f"{name}Color", candidates)
+        )
+
+        return ordered[:stops]
+
+    def _color_fill_stops(self, name: str) -> int:
+        range_ = self._options.color_fill_stops(name)
+
+        return (
+            2 if range_ is None else self._prng.integer(f"{name}ColorFillStops", range_)
+        )
+
+    def _memo_float(self, key: str, range_: Range | None, fallback: float) -> float:
+        return self._memo(
+            key, lambda: fallback if range_ is None else self._prng.float(key, range_)
+        )
+
+    def _memo(self, key: str, compute: Callable[[], T]) -> T:
+        if key in self._result:
+            return cast(T, self._result[key])
+
+        value = compute()
+        self._result[key] = value
+
+        return value

--- a/src/python/core/src/dicebear/style.py
+++ b/src/python/core/src/dicebear/style.py
@@ -1,0 +1,139 @@
+"""Validated, lazily-decomposed wrapper around a style definition."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, cast
+
+from .errors import ErrorDetail, StyleValidationError
+from .style_def.canvas import Canvas
+from .style_def.color import Color
+from .style_def.component import Component
+from .style_def.meta import Meta
+from .validator import StyleValidator
+
+
+class Style:
+    """Validated, lazily-decomposed wrapper around a style definition.
+
+    Construction runs the JSON Schema validator and stores a deep copy of the
+    input so that later mutation of the source object cannot leak into the
+    rendered avatar.
+    """
+
+    def __init__(self, data: Any) -> None:
+        StyleValidator.validate(data)
+
+        self._data: dict[str, Any] = copy.deepcopy(data)
+        self._meta: Meta | None = None
+        self._canvas: Canvas | None = None
+        self._components: dict[str, Component] | None = None
+        self._colors: dict[str, Color] | None = None
+
+        self._validate_aliases()
+
+    def id(self) -> str | None:
+        """Return the definition's ``$id``, or ``None`` when not set."""
+        return cast("str | None", self._data.get("$id"))
+
+    def schema(self) -> str | None:
+        """Return the definition's ``$schema`` URI, or ``None`` when not set."""
+        return cast("str | None", self._data.get("$schema"))
+
+    def comment(self) -> str | None:
+        """Return the definition's ``$comment``, or ``None`` when not set."""
+        return cast("str | None", self._data.get("$comment"))
+
+    def meta(self) -> Meta:
+        """Return the :class:`Meta` view, lazily constructed on first access."""
+        if self._meta is None:
+            self._meta = Meta(self._data.get("meta", {}))
+
+        return self._meta
+
+    def attributes(self) -> dict[str, Any]:
+        """Return the root SVG attributes, defaulting to an empty dict."""
+        return cast("dict[str, Any]", self._data.get("attributes", {}))
+
+    def canvas(self) -> Canvas:
+        """Return the :class:`Canvas` view, lazily constructed on first access."""
+        if self._canvas is None:
+            self._canvas = Canvas(self._data["canvas"])
+
+        return self._canvas
+
+    def components(self) -> dict[str, Component]:
+        """Return a name → :class:`Component` map, built lazily on first access."""
+        if self._components is not None:
+            return self._components
+
+        entries: dict[str, Any] = self._data.get("components", {})
+        self._components = {}
+
+        for name, data in entries.items():
+            if not self._is_alias(data):
+                self._components[name] = Component(name, data)
+
+        for name, data in entries.items():
+            if self._is_alias(data):
+                self._components[name] = Component(
+                    name, data, self._components.get(data["extends"])
+                )
+
+        return self._components
+
+    def colors(self) -> dict[str, Color]:
+        """Return a name → :class:`Color` map, built lazily on first access."""
+        if self._colors is None:
+            self._colors = {
+                name: Color(data) for name, data in self._data.get("colors", {}).items()
+            }
+
+        return self._colors
+
+    def _validate_aliases(self) -> None:
+        """Verify every ``extends`` references an existing, non-alias component.
+
+        The schema cannot enforce cross-references between sibling keys.
+        """
+        components: dict[str, Any] | None = self._data.get("components")
+
+        if components is None:
+            return
+
+        errors: list[ErrorDetail] = []
+
+        for name, data in components.items():
+            if not self._is_alias(data):
+                continue
+
+            target = data["extends"]
+            target_data = components.get(target)
+
+            if target_data is None:
+                errors.append(
+                    {
+                        "instancePath": f"/components/{name}/extends",
+                        "message": f'references unknown component "{target}"',
+                    }
+                )
+
+                continue
+
+            if self._is_alias(target_data):
+                errors.append(
+                    {
+                        "instancePath": f"/components/{name}/extends",
+                        "message": (
+                            f'references alias "{target}" — '
+                            "alias chains are not allowed"
+                        ),
+                    }
+                )
+
+        if len(errors) > 0:
+            raise StyleValidationError(errors)
+
+    @staticmethod
+    def _is_alias(data: dict[str, Any]) -> bool:
+        return "extends" in data

--- a/src/python/core/src/dicebear/style_def/__init__.py
+++ b/src/python/core/src/dicebear/style_def/__init__.py
@@ -1,0 +1,27 @@
+"""Read-only value objects mirroring the ``Style/*`` sub-views (PHP/JS ports)."""
+
+from __future__ import annotations
+
+from .canvas import Canvas
+from .color import Color
+from .component import Component
+from .component_translate import ComponentTranslate
+from .component_variant import ComponentVariant
+from .element import Element
+from .meta import Meta
+from .meta_creator import MetaCreator
+from .meta_license import MetaLicense
+from .meta_source import MetaSource
+
+__all__ = [
+    "Canvas",
+    "Color",
+    "Component",
+    "ComponentTranslate",
+    "ComponentVariant",
+    "Element",
+    "Meta",
+    "MetaCreator",
+    "MetaLicense",
+    "MetaSource",
+]

--- a/src/python/core/src/dicebear/style_def/canvas.py
+++ b/src/python/core/src/dicebear/style_def/canvas.py
@@ -1,0 +1,33 @@
+"""Read-only view over a style definition's ``canvas`` block."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from .element import Element
+
+
+class Canvas:
+    """Read-only view over a style definition's ``canvas`` block.
+
+    Exposes the drawing-area dimensions and the top-level element list.
+    """
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+        self._elements: list[Element] | None = None
+
+    def width(self) -> int | float:
+        """Return the canvas width — the viewBox ``width``."""
+        return cast("int | float", self._data["width"])
+
+    def height(self) -> int | float:
+        """Return the canvas height — the viewBox ``height``."""
+        return cast("int | float", self._data["height"])
+
+    def elements(self) -> list[Element]:
+        """Return the top-level elements, lazily wrapped on first access."""
+        if self._elements is None:
+            self._elements = [Element(el) for el in self._data["elements"]]
+
+        return self._elements

--- a/src/python/core/src/dicebear/style_def/color.py
+++ b/src/python/core/src/dicebear/style_def/color.py
@@ -1,0 +1,24 @@
+"""Read-only view over an entry in a style definition's ``colors`` block."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+
+class Color:
+    """Read-only view over an entry in a style definition's ``colors`` block."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    def values(self) -> list[str]:
+        """Return the candidate color values, in definition order."""
+        return cast("list[str]", self._data["values"])
+
+    def not_equal_to(self) -> list[str]:
+        """Return colors the resolver should avoid picking (empty when unset)."""
+        return cast("list[str]", self._data.get("notEqualTo", []))
+
+    def contrast_to(self) -> str | None:
+        """Return the name of a color to contrast against, or ``None``."""
+        return cast("str | None", self._data.get("contrastTo"))

--- a/src/python/core/src/dicebear/style_def/component.py
+++ b/src/python/core/src/dicebear/style_def/component.py
@@ -1,0 +1,107 @@
+"""Read-only view over an entry in a style definition's ``components`` block."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from .component_translate import ComponentTranslate
+from .component_variant import ComponentVariant
+
+
+class Component:
+    """Read-only view over an entry in a style definition's ``components`` block.
+
+    An entry is either a base component with its own dimensions and variants or
+    an alias declared via ``extends``. Aliases are pure references — they inherit
+    dimensions, variants, and all transforms from the source.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        data: dict[str, Any],
+        source: Component | None = None,
+    ) -> None:
+        self._name = name
+        self._data = data
+        self._source = source
+        self._translate: ComponentTranslate | None = None
+        self._variants: dict[str, ComponentVariant] | None = None
+
+    def name(self) -> str:
+        """Return the entry's own name as declared in the style definition.
+
+        For aliases this is the alias key, not the source component's name (use
+        :meth:`source_name` for the canonical user-option key prefix).
+        """
+        return self._name
+
+    def extends_name(self) -> str | None:
+        """Return the source component name for an alias, or ``None`` for a base."""
+        return cast("str | None", self._data.get("extends"))
+
+    def source_name(self) -> str:
+        """Return the canonical user-option key prefix.
+
+        The source component's name when this entry is an alias, otherwise the
+        entry's own name.
+        """
+        return self.extends_name() or self._name
+
+    def width(self) -> int | float:
+        """Return the component's intrinsic width (the source's, for aliases)."""
+        if self._source is not None:
+            return self._source.width()
+
+        return cast("int | float", self._data["width"])
+
+    def height(self) -> int | float:
+        """Return the component's intrinsic height (the source's, for aliases)."""
+        if self._source is not None:
+            return self._source.height()
+
+        return cast("int | float", self._data["height"])
+
+    def probability(self) -> int | float:
+        """Return the render probability (0–100). Aliases delegate; default 100."""
+        if self._source is not None:
+            return self._source.probability()
+
+        return cast("int | float", self._data.get("probability", 100))
+
+    def rotate(self) -> dict[str, Any] | None:
+        """Return the rotation range, or ``None`` when unset (aliases delegate)."""
+        if self._source is not None:
+            return self._source.rotate()
+
+        return cast("dict[str, Any] | None", self._data.get("rotate"))
+
+    def scale(self) -> dict[str, Any] | None:
+        """Return the scale range, or ``None`` when unset (aliases delegate)."""
+        if self._source is not None:
+            return self._source.scale()
+
+        return cast("dict[str, Any] | None", self._data.get("scale"))
+
+    def translate(self) -> ComponentTranslate:
+        """Return the translate descriptor (aliases delegate to the source)."""
+        if self._source is not None:
+            return self._source.translate()
+
+        if self._translate is None:
+            self._translate = ComponentTranslate(self._data.get("translate", {}))
+
+        return self._translate
+
+    def variants(self) -> dict[str, ComponentVariant]:
+        """Return a name → :class:`ComponentVariant` map (aliases delegate)."""
+        if self._source is not None:
+            return self._source.variants()
+
+        if self._variants is None:
+            self._variants = {
+                name: ComponentVariant(data)
+                for name, data in self._data["variants"].items()
+            }
+
+        return self._variants

--- a/src/python/core/src/dicebear/style_def/component_translate.py
+++ b/src/python/core/src/dicebear/style_def/component_translate.py
@@ -1,0 +1,20 @@
+"""Read-only view over a component's ``translate`` block."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+
+class ComponentTranslate:
+    """Read-only view over a component's ``translate`` block (X/Y offset ranges)."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    def x(self) -> dict[str, Any] | None:
+        """Return the X offset range, or ``None`` when unset."""
+        return cast("dict[str, Any] | None", self._data.get("x"))
+
+    def y(self) -> dict[str, Any] | None:
+        """Return the Y offset range, or ``None`` when unset."""
+        return cast("dict[str, Any] | None", self._data.get("y"))

--- a/src/python/core/src/dicebear/style_def/component_variant.py
+++ b/src/python/core/src/dicebear/style_def/component_variant.py
@@ -1,0 +1,26 @@
+"""Read-only view over an entry in a component's ``variants`` block."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from .element import Element
+
+
+class ComponentVariant:
+    """Read-only view over an entry in a component's ``variants`` block."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+        self._elements: list[Element] | None = None
+
+    def elements(self) -> list[Element]:
+        """Return the variant's elements, lazily wrapped on first access."""
+        if self._elements is None:
+            self._elements = [Element(el) for el in self._data["elements"]]
+
+        return self._elements
+
+    def weight(self) -> int | float:
+        """Return the weighted-pick weight for this variant, defaulting to ``1``."""
+        return cast("int | float", self._data.get("weight", 1))

--- a/src/python/core/src/dicebear/style_def/element.py
+++ b/src/python/core/src/dicebear/style_def/element.py
@@ -1,0 +1,42 @@
+"""Read-only view over a single render-tree element."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+
+class Element:
+    """Read-only view over a single render-tree element from a style definition.
+
+    The same node type covers SVG elements, text, and component references —
+    :meth:`type` discriminates between them.
+    """
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+        self._children: list[Element] | None = None
+
+    def type(self) -> str:
+        """Return the element type discriminator (``element``, ``text``, …)."""
+        return cast(str, self._data["type"])
+
+    def name(self) -> str | None:
+        """Return the element's tag/component name, or ``None`` when absent."""
+        return cast("str | None", self._data.get("name"))
+
+    def value(self) -> str | dict[str, Any] | None:
+        """Return the element's textual value or template fragment, or ``None``."""
+        return cast("str | dict[str, Any] | None", self._data.get("value"))
+
+    def attributes(self) -> dict[str, Any] | None:
+        """Return the element's raw attribute map, or ``None`` when undefined."""
+        return cast("dict[str, Any] | None", self._data.get("attributes"))
+
+    def children(self) -> list[Element]:
+        """Return the element's children, lazily wrapped on first access."""
+        if self._children is None:
+            self._children = [
+                Element(child) for child in self._data.get("children", [])
+            ]
+
+        return self._children

--- a/src/python/core/src/dicebear/style_def/meta.py
+++ b/src/python/core/src/dicebear/style_def/meta.py
@@ -1,0 +1,43 @@
+"""Lazily-constructed view over a style definition's ``meta`` block."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .meta_creator import MetaCreator
+from .meta_license import MetaLicense
+from .meta_source import MetaSource
+
+
+class Meta:
+    """Lazily-constructed view over a style definition's ``meta`` block.
+
+    Exposes the license, creator, and source descriptors.
+    """
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+        self._license: MetaLicense | None = None
+        self._creator: MetaCreator | None = None
+        self._source: MetaSource | None = None
+
+    def license(self) -> MetaLicense:
+        """Return the license descriptor, defaulting to an empty object."""
+        if self._license is None:
+            self._license = MetaLicense(self._data.get("license", {}))
+
+        return self._license
+
+    def creator(self) -> MetaCreator:
+        """Return the creator descriptor, defaulting to an empty object."""
+        if self._creator is None:
+            self._creator = MetaCreator(self._data.get("creator", {}))
+
+        return self._creator
+
+    def source(self) -> MetaSource:
+        """Return the source descriptor, defaulting to an empty object."""
+        if self._source is None:
+            self._source = MetaSource(self._data.get("source", {}))
+
+        return self._source

--- a/src/python/core/src/dicebear/style_def/meta_creator.py
+++ b/src/python/core/src/dicebear/style_def/meta_creator.py
@@ -1,0 +1,20 @@
+"""Read-only view over the ``meta.creator`` block of a style definition."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+
+class MetaCreator:
+    """Read-only view over the ``meta.creator`` block of a style definition."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    def name(self) -> str | None:
+        """Return the creator's display name, or ``None`` when not set."""
+        return cast("str | None", self._data.get("name"))
+
+    def url(self) -> str | None:
+        """Return the creator's homepage URL, or ``None`` when not set."""
+        return cast("str | None", self._data.get("url"))

--- a/src/python/core/src/dicebear/style_def/meta_license.py
+++ b/src/python/core/src/dicebear/style_def/meta_license.py
@@ -1,0 +1,24 @@
+"""Read-only view over the ``meta.license`` block of a style definition."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+
+class MetaLicense:
+    """Read-only view over the ``meta.license`` block of a style definition."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    def name(self) -> str | None:
+        """Return the license name (e.g. ``"CC BY 4.0"``), or ``None``."""
+        return cast("str | None", self._data.get("name"))
+
+    def url(self) -> str | None:
+        """Return the license URL, or ``None`` when not set."""
+        return cast("str | None", self._data.get("url"))
+
+    def text(self) -> str | None:
+        """Return the full license text, or ``None`` when not set."""
+        return cast("str | None", self._data.get("text"))

--- a/src/python/core/src/dicebear/style_def/meta_source.py
+++ b/src/python/core/src/dicebear/style_def/meta_source.py
@@ -1,0 +1,20 @@
+"""Read-only view over the ``meta.source`` block of a style definition."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+
+class MetaSource:
+    """Read-only view over the ``meta.source`` block of a style definition."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    def name(self) -> str | None:
+        """Return the source name (e.g. the original work title), or ``None``."""
+        return cast("str | None", self._data.get("name"))
+
+    def url(self) -> str | None:
+        """Return the URL of the source, or ``None`` when not set."""
+        return cast("str | None", self._data.get("url"))

--- a/src/python/core/src/dicebear/utils/__init__.py
+++ b/src/python/core/src/dicebear/utils/__init__.py
@@ -1,0 +1,11 @@
+"""Stateless helpers used by the renderer and resolver."""
+
+from __future__ import annotations
+
+from .color import Color
+from .initials import Initials
+from .license import License
+from .number import Number
+from .xml import Xml
+
+__all__ = ["Color", "Initials", "License", "Number", "Xml"]

--- a/src/python/core/src/dicebear/utils/color.py
+++ b/src/python/core/src/dicebear/utils/color.py
@@ -1,0 +1,90 @@
+"""Color helpers used by the renderer and option resolver."""
+
+from __future__ import annotations
+
+
+class Color:
+    """Color helpers used by the renderer and option resolver."""
+
+    @staticmethod
+    def to_hex(hex_value: str) -> str:
+        """Normalize any hex format to 6- or 8-digit lowercase with ``#`` prefix."""
+        normalized = hex_value.lstrip("#").lower()
+
+        if len(normalized) == 3:
+            r, g, b = normalized[0], normalized[1], normalized[2]
+            return f"#{r}{r}{g}{g}{b}{b}"
+
+        if len(normalized) == 4:
+            r, g, b, a = normalized[0], normalized[1], normalized[2], normalized[3]
+            return f"#{r}{r}{g}{g}{b}{b}{a}{a}"
+
+        return "#" + normalized
+
+    @staticmethod
+    def to_rgb_hex(hex_value: str) -> str:
+        """Like :meth:`to_hex`, but strip the alpha channel (always 6-digit)."""
+        full = Color.to_hex(hex_value)
+
+        return full[:7] if len(full) > 7 else full
+
+    @staticmethod
+    def parse_hex(hex_value: str) -> tuple[int, int, int]:
+        """Parse a hex color into an ``(r, g, b)`` triple of 8-bit channels."""
+        digits = Color.to_hex(hex_value)[1:]
+
+        return (
+            int(digits[0:2], 16),
+            int(digits[2:4], 16),
+            int(digits[4:6], 16),
+        )
+
+    @staticmethod
+    def luminance(hex_value: str) -> float:
+        """WCAG 2.1 relative luminance with sRGB linearization.
+
+        See https://www.w3.org/WAI/GL/wiki/Relative_luminance
+        """
+        r, g, b = Color.parse_hex(hex_value)
+
+        return 0.2126 * _linearize(r) + 0.7152 * _linearize(g) + 0.0722 * _linearize(b)
+
+    @staticmethod
+    def sort_by_contrast(candidates: list[str], ref_color: str) -> list[str]:
+        """Return a new list sorted by descending contrast against ``ref_color``.
+
+        See https://www.w3.org/WAI/GL/wiki/Contrast_ratio
+        """
+        ref_lum = Color.luminance(ref_color)
+
+        def ratio(color: str) -> float:
+            lum = Color.luminance(color)
+            return (max(lum, ref_lum) + 0.05) / (min(lum, ref_lum) + 0.05)
+
+        # Stable sort by descending ratio, matching JS/PHP comparator parity:
+        # equal ratios keep their original (already code-point-sorted) order.
+        return sorted(candidates, key=ratio, reverse=True)
+
+    @staticmethod
+    def filter_not_equal_to(candidates: list[str], excluded: list[str]) -> list[str]:
+        """Return a new list with excluded colors removed.
+
+        Falls back to the original candidates when filtering would empty the list.
+        """
+        normalized = {Color.to_rgb_hex(color) for color in excluded}
+
+        filtered = [
+            color for color in candidates if Color.to_rgb_hex(color) not in normalized
+        ]
+
+        return filtered if len(filtered) > 0 else candidates
+
+
+def _linearize(channel: int) -> float:
+    """Convert an 8-bit sRGB channel value into linear-light space."""
+    srgb = channel / 255
+
+    if srgb <= 0.04045:
+        return srgb / 12.92
+
+    return float(((srgb + 0.055) / 1.055) ** 2.4)

--- a/src/python/core/src/dicebear/utils/initials.py
+++ b/src/python/core/src/dicebear/utils/initials.py
@@ -1,0 +1,101 @@
+"""Derive display initials from a seed string."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+# Backtick, acute accent, apostrophe, and modifier letter apostrophe — stripped
+# so names like "O'Brien" yield "OB" rather than "OB" split on the quote.
+_QUOTES = re.compile(r"[`´'ʼ]")
+_AT_TAIL = re.compile(r"@.*")
+
+
+class Initials:
+    """Derive display initials from a seed string."""
+
+    @staticmethod
+    def from_seed(seed: str, discard_at_symbol: bool = True) -> str:
+        """Return one or two uppercase initials for the given seed.
+
+        By default strips ``@...`` so email addresses yield a single initial
+        instead of being treated as two words.
+        """
+        text = _AT_TAIL.sub("", seed) if discard_at_symbol else seed
+        text = _QUOTES.sub("", text)
+
+        words = _words(text)
+
+        if len(words) == 0:
+            return Initials.from_seed(seed, False) if discard_at_symbol else ""
+
+        if len(words) == 1:
+            return _clusters(words[0], 2).upper()
+
+        first = _clusters(words[0], 1)
+        last = _clusters(words[-1], 1)
+
+        if first == "" or last == "":
+            return ""
+
+        return (first + last).upper()
+
+
+def _is_letter(char: str) -> bool:
+    """Whether ``char`` is a Unicode letter (PCRE ``\\p{L}``)."""
+    return unicodedata.category(char)[0] == "L"
+
+
+def _is_mark(char: str) -> bool:
+    """Whether ``char`` is a Unicode combining mark (PCRE ``\\p{M}``)."""
+    return unicodedata.category(char)[0] == "M"
+
+
+def _words(text: str) -> list[str]:
+    """Split into maximal runs that start with a letter and continue with
+    letters or marks — the matches of ``(\\p{L}[\\p{L}\\p{M}]*)``.
+    """
+    words: list[str] = []
+    current: list[str] = []
+
+    for char in text:
+        if current:
+            if _is_letter(char) or _is_mark(char):
+                current.append(char)
+            else:
+                words.append("".join(current))
+                current = []
+                if _is_letter(char):
+                    current.append(char)
+        elif _is_letter(char):
+            current.append(char)
+
+    if current:
+        words.append("".join(current))
+
+    return words
+
+
+def _clusters(word: str, limit: int) -> str:
+    """Return up to ``limit`` leading letter-plus-marks clusters of ``word``.
+
+    Mirrors ``(?:\\p{L}\\p{M}*){limit}`` anchored at the start.
+    """
+    result: list[str] = []
+    count = 0
+    i = 0
+
+    while i < len(word) and count < limit:
+        if not _is_letter(word[i]):
+            break
+
+        result.append(word[i])
+        i += 1
+
+        while i < len(word) and _is_mark(word[i]):
+            result.append(word[i])
+            i += 1
+
+        count += 1
+
+    return "".join(result)

--- a/src/python/core/src/dicebear/utils/license.py
+++ b/src/python/core/src/dicebear/utils/license.py
@@ -1,0 +1,112 @@
+"""Attribution strings and embedded RDF/Dublin Core metadata."""
+
+from __future__ import annotations
+
+from ..style_def.meta import Meta
+from .xml import Xml
+
+
+class License:
+    """Builds attribution strings and embedded RDF/Dublin Core metadata from a
+    style's :class:`Meta` block.
+    """
+
+    @staticmethod
+    def text(meta: Meta) -> str:
+        """Return a single-line attribution string for ``<title>``/``<desc>``.
+
+        Returns an empty string when no attribution data is available.
+        """
+        source_name = meta.source().name()
+        source_url = meta.source().url()
+        creator_name = meta.creator().name()
+        license_name = meta.license().name()
+        license_url = meta.license().url()
+
+        if source_name is None and creator_name is None and license_name is None:
+            return ""
+
+        title = f"“{source_name}”" if source_name is not None else "Design"
+
+        if source_url is not None:
+            title += f" ({source_url})"
+
+        creator = "“" + (creator_name if creator_name is not None else "Unknown") + "”"
+
+        result = ""
+
+        # Skip "Remix of" prefix for MIT-licensed or DiceBear-original styles.
+        if (
+            license_name != "MIT"
+            and creator_name != "DiceBear"
+            and source_name is not None
+        ):
+            result += "Remix of "
+
+        result += f"{title} by {creator}"
+
+        if license_name is not None:
+            result += f", licensed under “{license_name}”"
+
+            if license_url is not None:
+                result += f" ({license_url})"
+
+        return result
+
+    @staticmethod
+    def xml(meta: Meta) -> str:
+        """Build an embedded ``<metadata>`` block with Dublin Core terms.
+
+        Returns an empty string when no metadata fields are populated.
+        """
+        title = meta.source().name()
+        creator_name = meta.creator().name()
+        source_url = meta.source().url()
+        license_url = meta.license().url()
+        rights = License.text(meta)
+
+        if (
+            title is None
+            and creator_name is None
+            and source_url is None
+            and license_url is None
+            and rights == ""
+        ):
+            return ""
+
+        fields: list[str] = []
+
+        if title is not None:
+            fields.append("<dc:title>" + Xml.escape(title) + "</dc:title>")
+
+        if creator_name is not None:
+            fields.append("<dc:creator>" + Xml.escape(creator_name) + "</dc:creator>")
+
+        if source_url is not None:
+            fields.append(
+                '<dc:source xsi:type="dcterms:URI">'
+                + Xml.escape(source_url)
+                + "</dc:source>"
+            )
+
+        if license_url is not None:
+            fields.append(
+                '<dcterms:license xsi:type="dcterms:URI">'
+                + Xml.escape(license_url)
+                + "</dcterms:license>"
+            )
+
+        if rights != "":
+            fields.append("<dc:rights>" + Xml.escape(rights) + "</dc:rights>")
+
+        return (
+            "<metadata"
+            ' xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"'
+            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
+            ' xmlns:dc="http://purl.org/dc/elements/1.1/"'
+            ' xmlns:dcterms="http://purl.org/dc/terms/">'
+            "<rdf:RDF><rdf:Description>"
+            + "".join(fields)
+            + "</rdf:Description></rdf:RDF>"
+            "</metadata>"
+        )

--- a/src/python/core/src/dicebear/utils/number.py
+++ b/src/python/core/src/dicebear/utils/number.py
@@ -1,0 +1,52 @@
+"""Formats a number for SVG output, rounded to at most 5 decimal places.
+
+Rounding to a fixed precision keeps the output bounded and identical across
+the JS, PHP, and Python ports: every value becomes a multiple of 1e-5 in the
+SVG coordinate range, which has no exponential form, so the result is built
+from integer arithmetic — sidestepping Python's ``repr`` (which would emit
+``"1e-05"`` and diverge from the JS reference). Five decimals is far below
+sub-pixel precision for any realistic canvas.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+class Number:
+    """Formats numbers for SVG output with cross-language byte parity."""
+
+    @staticmethod
+    def format(value: float) -> str:
+        """Return ``value`` rounded to at most 5 decimal places as a string."""
+        if value != value:  # NaN
+            return "NaN"
+
+        if value == math.inf:
+            return "Infinity"
+
+        if value == -math.inf:
+            return "-Infinity"
+
+        scaled = Number.round_half_up(value * 100000)
+        sign = "-" if scaled < 0 else ""
+        scaled = abs(scaled)
+
+        integer_part = scaled // 100000
+        fraction = f"{scaled % 100000:05d}".rstrip("0")
+
+        return f"{sign}{integer_part}{'.' + fraction if fraction else ''}"
+
+    @staticmethod
+    def round_half_up(value: float) -> int:
+        """Round half toward +Infinity, matching JavaScript's ``Math.round``.
+
+        Python's built-in ``round`` uses banker's rounding (half to even). The
+        naive ``floor(value + 0.5)`` also diverges: for the largest double below
+        0.5 (``0.49999999999999994``) the addition rounds up to ``1.0`` and
+        yields ``1``, whereas ``Math.round`` returns ``0``. Comparing the
+        fractional part against ``0.5`` reproduces ``Math.round`` exactly.
+        """
+        floor = math.floor(value)
+
+        return floor if value - floor < 0.5 else floor + 1

--- a/src/python/core/src/dicebear/utils/xml.py
+++ b/src/python/core/src/dicebear/utils/xml.py
@@ -1,0 +1,22 @@
+"""Minimal XML escaping helper for SVG/XML text and attribute content."""
+
+from __future__ import annotations
+
+_ENTITIES = {
+    "&": "&amp;",
+    "'": "&apos;",
+    '"': "&quot;",
+    "<": "&lt;",
+    ">": "&gt;",
+}
+
+_TABLE = str.maketrans(_ENTITIES)
+
+
+class Xml:
+    """Minimal XML escaping helper for SVG/XML text and attribute content."""
+
+    @staticmethod
+    def escape(value: str) -> str:
+        """Return ``value`` with the five XML predefined entities escaped."""
+        return value.translate(_TABLE)

--- a/src/python/core/src/dicebear/validator.py
+++ b/src/python/core/src/dicebear/validator.py
@@ -1,0 +1,85 @@
+"""JSON Schema validation against the shared draft-07 schemas."""
+
+from __future__ import annotations
+
+import json
+from importlib.resources import files
+from typing import Any
+
+from jsonschema import Draft7Validator
+from jsonschema.exceptions import ValidationError as JsonSchemaError
+
+from .errors import ErrorDetail, OptionsValidationError, StyleValidationError
+
+_MAX_ERRORS = 10
+
+_validators: dict[str, Draft7Validator] = {}
+
+
+def _validator(filename: str) -> Draft7Validator:
+    """Return the cached :class:`Draft7Validator` for a shared schema file.
+
+    The two draft-07 schemas (``definition.json`` / ``options.json``) ship as
+    the ``dicebear-schema`` package — the Python counterpart of the
+    ``@dicebear/schema`` (npm) / ``dicebear/schema`` (Composer) packages the
+    JS/PHP ports pin — and are read via :func:`importlib.resources.files`.
+    """
+    if filename not in _validators:
+        raw = files("dicebear_schema").joinpath(filename).read_text("utf-8")
+        _validators[filename] = Draft7Validator(json.loads(raw))
+
+    return _validators[filename]
+
+
+def _collect(error: JsonSchemaError, details: list[ErrorDetail]) -> None:
+    """Flatten a jsonschema error tree into ``{message, instancePath}`` leaves."""
+    if error.context:
+        for sub in error.context:
+            _collect(sub, details)
+
+        return
+
+    path = list(error.absolute_path)
+    instance_path = "/" + "/".join(str(p) for p in path) if path else ""
+
+    details.append({"message": str(error.validator), "instancePath": instance_path})
+
+
+def _details(filename: str, data: Any) -> list[ErrorDetail]:
+    """Return validation failures for ``data`` against the named schema."""
+    errors = sorted(
+        _validator(filename).iter_errors(data),
+        key=lambda e: list(e.absolute_path),
+    )
+
+    details: list[ErrorDetail] = []
+
+    for error in errors[:_MAX_ERRORS]:
+        _collect(error, details)
+
+    if errors and len(details) == 0:
+        details.append({"message": "Validation failed"})
+
+    return details
+
+
+class StyleValidator:
+    """Validates style definitions against the shared ``definition.json`` schema."""
+
+    @staticmethod
+    def validate(data: Any) -> None:
+        details = _details("definition.json", data)
+
+        if len(details) > 0:
+            raise StyleValidationError(details)
+
+
+class OptionsValidator:
+    """Validates avatar options against the shared ``options.json`` schema."""
+
+    @staticmethod
+    def validate(data: Any) -> None:
+        details = _details("options.json", data)
+
+        if len(details) > 0:
+            raise OptionsValidationError(details)

--- a/src/python/core/tests/test_avatar.py
+++ b/src/python/core/tests/test_avatar.py
@@ -1,0 +1,118 @@
+"""Tests for the Avatar entry point."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dicebear import Avatar, Style
+
+
+def _minimal_style_data() -> dict[str, Any]:
+    return {"canvas": {"width": 100, "height": 100, "elements": []}}
+
+
+# ---------------------------------------------------------------------------
+# constructor
+# ---------------------------------------------------------------------------
+
+
+def test_accepts_style_instance_and_raw_options() -> None:
+    style = Style(_minimal_style_data())
+    assert isinstance(Avatar(style, {"seed": "test"}), Avatar)
+
+
+def test_accepts_raw_style_data() -> None:
+    assert isinstance(Avatar(_minimal_style_data()), Avatar)
+
+
+def test_accepts_raw_style_data_and_raw_options() -> None:
+    assert isinstance(Avatar(_minimal_style_data(), {"seed": "test"}), Avatar)
+
+
+def test_works_without_options() -> None:
+    style = Style(_minimal_style_data())
+    assert isinstance(Avatar(style), Avatar)
+
+
+# ---------------------------------------------------------------------------
+# to_string
+# ---------------------------------------------------------------------------
+
+
+def test_to_string_returns_string() -> None:
+    style = Style(_minimal_style_data())
+    assert isinstance(Avatar(style, {"seed": "test"}).to_string(), str)
+
+
+def test_str_matches_to_string() -> None:
+    style = Style(_minimal_style_data())
+    avatar = Avatar(style, {"seed": "test"})
+    assert str(avatar) == avatar.to_string()
+
+
+# ---------------------------------------------------------------------------
+# to_json
+# ---------------------------------------------------------------------------
+
+
+def test_to_json_returns_object_with_svg_and_options() -> None:
+    style = Style(_minimal_style_data())
+    result = Avatar(style, {"seed": "test"}).to_json()
+    assert isinstance(result["svg"], str)
+    assert isinstance(result["options"], dict)
+
+
+def test_to_json_consistent_with_to_string() -> None:
+    style = Style(_minimal_style_data())
+    avatar = Avatar(style, {"seed": "test"})
+    assert avatar.to_json()["svg"] == avatar.to_string()
+
+
+def test_to_json_returns_deep_copy_of_options() -> None:
+    style = Style(_minimal_style_data())
+    avatar = Avatar(style, {"seed": "test"})
+    json1 = avatar.to_json()
+    json2 = avatar.to_json()
+    json1["options"]["injected"] = "modified"
+    assert "injected" not in json2["options"]
+
+
+def test_to_json_does_not_include_seed() -> None:
+    style = Style(_minimal_style_data())
+    avatar = Avatar(style, {"seed": "test"})
+    assert "seed" not in avatar.to_json()["options"]
+
+
+# ---------------------------------------------------------------------------
+# to_data_uri
+# ---------------------------------------------------------------------------
+
+
+def test_to_data_uri_returns_data_uri() -> None:
+    style = Style(_minimal_style_data())
+    assert (
+        Avatar(style, {"seed": "test"})
+        .to_data_uri()
+        .startswith("data:image/svg+xml;charset=utf-8,")
+    )
+
+
+def test_to_data_uri_encodes_like_encodeuricomponent() -> None:
+    # Independent of the implementation's quote() call: assert the actual
+    # encodeURIComponent semantics the JS/PHP ports also produce, so a
+    # regression (e.g. to quote_plus, or a wrong safe set) fails here.
+    style = Style(_minimal_style_data())
+    avatar = Avatar(style, {"seed": "test"})
+    svg = avatar.to_string()
+    prefix = "data:image/svg+xml;charset=utf-8,"
+    payload = avatar.to_data_uri().removeprefix(prefix)
+
+    # Structural XML characters must be percent-encoded, none left raw.
+    assert "%3C" in payload and "%3E" in payload  # < >
+    assert "%22" in payload  # "
+    assert not any(c in payload for c in '<>"')
+    # Spaces become %20 (never '+'); '#' (from url(#clip-…)) becomes %23.
+    assert " " in svg and "%20" in payload and "+" not in payload
+    assert "%23" in payload and "#" not in payload
+    # encodeURIComponent leaves these unescaped; quote() must match.
+    assert "(" in payload and ")" in payload and "%28" not in payload

--- a/src/python/core/tests/test_options.py
+++ b/src/python/core/tests/test_options.py
@@ -1,0 +1,197 @@
+"""Tests for option parsing and normalization."""
+
+from __future__ import annotations
+
+import pytest
+
+from dicebear.errors import OptionsValidationError, ValidationError
+from dicebear.options import Options
+
+# ---------------------------------------------------------------------------
+# constructor
+# ---------------------------------------------------------------------------
+
+
+def test_accepts_empty_data() -> None:
+    assert Options({}) is not None
+
+
+def test_accepts_none_data() -> None:
+    assert Options() is not None
+
+
+def test_accepts_full_input_data() -> None:
+    options = Options(
+        {"seed": "test-seed", "size": 128, "flip": "horizontal", "scale": 1.2}
+    )
+    assert options is not None
+
+
+def test_throws_options_validation_error() -> None:
+    with pytest.raises(OptionsValidationError):
+        Options({"size": -1})
+
+
+def test_throws_validation_error() -> None:
+    with pytest.raises(ValidationError):
+        Options({"size": -1})
+
+
+def test_error_includes_details() -> None:
+    with pytest.raises(OptionsValidationError) as exc_info:
+        Options({"size": -1})
+    assert isinstance(exc_info.value.details, list)
+    assert len(exc_info.value.details) > 0
+
+
+# ---------------------------------------------------------------------------
+# scalar passthroughs
+# ---------------------------------------------------------------------------
+
+
+def test_scalars_return_none_when_unset() -> None:
+    options = Options({})
+    assert options.seed() is None
+    assert options.size() is None
+    assert options.id_randomization() is None
+    assert options.title() is None
+
+
+def test_scalars_return_user_set_values() -> None:
+    options = Options(
+        {"seed": "abc", "size": 256, "idRandomization": True, "title": "My Avatar"}
+    )
+    assert options.seed() == "abc"
+    assert options.size() == 256
+    assert options.id_randomization() is True
+    assert options.title() == "My Avatar"
+
+
+# ---------------------------------------------------------------------------
+# top-level normalization
+# ---------------------------------------------------------------------------
+
+
+def test_normalizes_scalar_list_to_one_element_list() -> None:
+    assert Options({"flip": "horizontal"}).flip() == ["horizontal"]
+
+
+def test_passes_list_array_through() -> None:
+    assert Options({"flip": ["horizontal", "vertical"]}).flip() == [
+        "horizontal",
+        "vertical",
+    ]
+
+
+def test_normalizes_scalar_range_to_fixed_value() -> None:
+    assert Options({"scale": 1.5}).scale() == {"min": 1.5, "max": 1.5}
+
+
+def test_normalizes_range_tuple_to_object() -> None:
+    assert Options({"scale": [0.8, 1.2]}).scale() == {"min": 0.8, "max": 1.2}
+
+
+def test_single_element_range_array_is_a_fixed_value() -> None:
+    # `[n]` behaves like the scalar `n`; an empty array is unset (default).
+    assert Options({"scale": [2]}).scale() == {"min": 2, "max": 2}
+    assert Options({"scale": []}).scale() is None
+
+
+def test_returns_none_for_unset_range_options() -> None:
+    options = Options({})
+    assert options.scale() is None
+    assert options.border_radius() is None
+    assert options.rotate() is None
+    assert options.translate_x() is None
+    assert options.translate_y() is None
+
+
+def test_returns_empty_array_for_unset_list_options() -> None:
+    options = Options({})
+    assert options.flip() == []
+    assert options.font_family() == []
+    assert options.font_weight() == []
+
+
+# ---------------------------------------------------------------------------
+# component_variant
+# ---------------------------------------------------------------------------
+
+
+def test_component_variant_returns_none_when_unset() -> None:
+    assert Options({}).component_variant("eyes") is None
+
+
+def test_component_variant_normalizes_string_to_weighted_map() -> None:
+    assert Options({"eyesVariant": "open"}).component_variant("eyes") == {"open": 1}
+
+
+def test_component_variant_normalizes_list_to_weighted_map() -> None:
+    assert Options({"eyesVariant": ["open", "closed"]}).component_variant("eyes") == {
+        "open": 1,
+        "closed": 1,
+    }
+
+
+def test_component_variant_passes_weighted_record_through() -> None:
+    assert Options({"eyesVariant": {"open": 5, "closed": 1}}).component_variant(
+        "eyes"
+    ) == {"open": 5, "closed": 1}
+
+
+# ---------------------------------------------------------------------------
+# component_probability
+# ---------------------------------------------------------------------------
+
+
+def test_component_probability_returns_none_when_unset() -> None:
+    assert Options({}).component_probability("eyes") is None
+
+
+def test_component_probability_returns_value() -> None:
+    assert Options({"eyesProbability": 80}).component_probability("eyes") == 80
+
+
+# ---------------------------------------------------------------------------
+# color
+# ---------------------------------------------------------------------------
+
+
+def test_color_returns_none_when_unset() -> None:
+    assert Options({}).color("skin") is None
+
+
+def test_color_normalizes_single_hex() -> None:
+    assert Options({"skinColor": "#f0c8a0"}).color("skin") == ["#f0c8a0"]
+
+
+def test_color_passes_list_through() -> None:
+    assert Options({"skinColor": ["#f0c8a0", "#d4a574"]}).color("skin") == [
+        "#f0c8a0",
+        "#d4a574",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# color_fill / color_angle / color_fill_stops
+# ---------------------------------------------------------------------------
+
+
+def test_color_meta_normalizes() -> None:
+    options = Options(
+        {
+            "skinColorFill": "linear",
+            "skinColorAngle": 45,
+            "skinColorFillStops": [2, 4],
+        }
+    )
+    assert options.color_fill("skin") == ["linear"]
+    assert options.color_angle("skin") == {"min": 45, "max": 45}
+    assert options.color_fill_stops("skin") == {"min": 2, "max": 4}
+
+
+def test_color_meta_defaults_when_unset() -> None:
+    options = Options({})
+    assert options.color_fill("skin") == []
+    assert options.color_angle("skin") is None
+    assert options.color_fill_stops("skin") is None

--- a/src/python/core/tests/test_options_descriptor.py
+++ b/src/python/core/tests/test_options_descriptor.py
@@ -1,0 +1,165 @@
+"""Tests for the options descriptor."""
+
+from __future__ import annotations
+
+from dicebear import OptionsDescriptor, Style
+
+
+def _minimal_style() -> Style:
+    return Style({"canvas": {"width": 100, "height": 100, "elements": []}})
+
+
+def _full_style() -> Style:
+    return Style(
+        {
+            "canvas": {"width": 100, "height": 100, "elements": []},
+            "components": {
+                "eyes": {
+                    "width": 100,
+                    "height": 100,
+                    "variants": {
+                        "open": {"elements": []},
+                        "closed": {"elements": []},
+                        "wink": {"elements": []},
+                    },
+                },
+                "mouth": {
+                    "width": 100,
+                    "height": 100,
+                    "variants": {
+                        "happy": {"elements": []},
+                        "sad": {"elements": []},
+                    },
+                },
+            },
+            "colors": {
+                "skin": {"values": ["#ff0000", "#00ff00"]},
+                "hair": {"values": ["#000000"]},
+                "text": {
+                    "values": ["#ffffff", "#000000"],
+                    "contrastTo": "background",
+                },
+            },
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# base options
+# ---------------------------------------------------------------------------
+
+
+def test_includes_all_base_options() -> None:
+    schema = OptionsDescriptor(_minimal_style()).to_json()
+    assert schema["seed"] == {"type": "string"}
+    assert schema["size"] == {"type": "number", "min": 1, "max": 4096}
+    assert schema["idRandomization"] == {"type": "boolean"}
+    assert schema["flip"] == {
+        "type": "enum",
+        "values": ["none", "horizontal", "vertical", "both"],
+        "list": True,
+    }
+    assert schema["scale"] == {"type": "range", "min": 0, "max": 10}
+    assert schema["borderRadius"] == {"type": "range", "min": 0, "max": 50}
+    assert schema["rotate"] == {"type": "range", "min": -360, "max": 360}
+    assert schema["translateX"] == {"type": "range", "min": -1000, "max": 1000}
+    assert schema["translateY"] == {"type": "range", "min": -1000, "max": 1000}
+    assert schema["fontFamily"] == {"type": "string", "list": True}
+    assert schema["fontWeight"] == {
+        "type": "number",
+        "min": 1,
+        "max": 1000,
+        "list": True,
+    }
+
+
+def test_always_includes_background_color_options() -> None:
+    schema = OptionsDescriptor(_minimal_style()).to_json()
+    assert schema["backgroundColor"] == {"type": "color", "list": True}
+    assert schema["backgroundColorFill"] == {
+        "type": "enum",
+        "values": ["solid", "linear", "radial"],
+        "list": True,
+    }
+    assert schema["backgroundColorFillStops"] == {"type": "range", "min": 2}
+    assert schema["backgroundColorAngle"] == {"type": "range", "min": -360, "max": 360}
+
+
+# ---------------------------------------------------------------------------
+# component options
+# ---------------------------------------------------------------------------
+
+
+def test_generates_component_options() -> None:
+    schema = OptionsDescriptor(_full_style()).to_json()
+    assert "eyesVariant" in schema
+    assert "eyesProbability" in schema
+    assert "eyesRotate" not in schema
+    assert "eyesTranslateX" not in schema
+    assert "eyesTranslateY" not in schema
+    assert "eyesScale" not in schema
+    assert "mouthVariant" in schema
+
+
+def test_root_scale_constraints() -> None:
+    schema = OptionsDescriptor(_full_style()).to_json()
+    assert schema["scale"] == {"type": "range", "min": 0, "max": 10}
+
+
+def test_sorted_variant_names() -> None:
+    schema = OptionsDescriptor(_full_style()).to_json()
+    assert schema["eyesVariant"] == {
+        "type": "enum",
+        "values": ["closed", "open", "wink"],
+        "list": True,
+        "weighted": True,
+    }
+
+
+def test_probability_constraints() -> None:
+    schema = OptionsDescriptor(_full_style()).to_json()
+    assert schema["eyesProbability"] == {"type": "number", "min": 0, "max": 100}
+
+
+# ---------------------------------------------------------------------------
+# color options
+# ---------------------------------------------------------------------------
+
+
+def test_generates_color_options() -> None:
+    schema = OptionsDescriptor(_full_style()).to_json()
+    assert schema["skinColor"] == {"type": "color", "list": True}
+    assert schema["hairColor"] == {"type": "color", "list": True}
+    assert schema["skinColorFill"] == {
+        "type": "enum",
+        "values": ["solid", "linear", "radial"],
+        "list": True,
+    }
+
+
+def test_exposes_contrast_to_on_color_fields() -> None:
+    schema = OptionsDescriptor(_full_style()).to_json()
+    assert schema["textColor"] == {
+        "type": "color",
+        "list": True,
+        "contrastTo": "background",
+    }
+    assert "contrastTo" not in schema["skinColor"]
+
+
+# ---------------------------------------------------------------------------
+# caching
+# ---------------------------------------------------------------------------
+
+
+def test_structurally_equal() -> None:
+    descriptor = OptionsDescriptor(_full_style())
+    assert descriptor.to_json() == descriptor.to_json()
+
+
+def test_returns_independent_copies() -> None:
+    descriptor = OptionsDescriptor(_full_style())
+    a = descriptor.to_json()
+    b = descriptor.to_json()
+    a["seed"] = {"type": "mutated"}
+    assert a["seed"] != b["seed"]

--- a/src/python/core/tests/test_parity.py
+++ b/src/python/core/tests/test_parity.py
@@ -1,0 +1,174 @@
+"""Cross-language parity tests.
+
+Reads the shared fixtures at ``tests/fixtures/parity/`` and asserts that the
+Python implementation produces exactly the values committed there. The JS suite
+(``src/js/core/tests/Parity.test.js``) and the PHP suite
+(``src/php/core/tests/ParityTest.php``) read the same fixtures, so any
+divergence between implementations surfaces as a failure on whichever side
+drifts.
+
+To regenerate the fixtures: ``npm run fixtures:parity`` (from repo root).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from dicebear import Avatar
+from dicebear.prng import Fnv1a, Mulberry32, Prng
+from dicebear.utils import Initials, Number
+
+FIXTURES_DIR = Path(__file__).parents[4] / "tests" / "fixtures" / "parity"
+
+
+def _load(rel_path: str) -> Any:
+    return json.loads((FIXTURES_DIR / rel_path).read_text("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Fnv1a
+# ---------------------------------------------------------------------------
+
+_FNV1A = _load("fnv1a.json")
+
+
+@pytest.mark.parametrize("entry", _FNV1A, ids=[repr(e["input"]) for e in _FNV1A])
+def test_fnv1a(entry: dict[str, Any]) -> None:
+    assert Fnv1a.hash(entry["input"]) == entry["hash"]
+    assert Fnv1a.hex(entry["input"]) == entry["hex"]
+
+
+# ---------------------------------------------------------------------------
+# Mulberry32
+# ---------------------------------------------------------------------------
+
+_MULBERRY32 = _load("mulberry32.json")
+
+
+@pytest.mark.parametrize(
+    "entry", _MULBERRY32, ids=[f"seed-{e['seed']}" for e in _MULBERRY32]
+)
+def test_mulberry32(entry: dict[str, Any]) -> None:
+    mulberry = Mulberry32(entry["seed"])
+
+    for i, expected in enumerate(entry["sequence"]):
+        assert mulberry.next_float() == expected["float"], f"step {i} float"
+        assert mulberry.state() == expected["state"], f"step {i} state"
+
+
+# ---------------------------------------------------------------------------
+# Prng
+# ---------------------------------------------------------------------------
+
+_PRNG = _load("prng.json")
+
+
+def _prng_params(method: str) -> dict[str, Any]:
+    cases = _PRNG[method]
+    return {
+        "argvalues": cases,
+        "ids": [f"#{i}-{c['seed']}-{c['key']}" for i, c in enumerate(cases)],
+    }
+
+
+@pytest.mark.parametrize("c", **_prng_params("getValue"))
+def test_prng_get_value(c: dict[str, Any]) -> None:
+    assert Prng(c["seed"]).get_value(c["key"]) == c["result"]
+
+
+@pytest.mark.parametrize("c", **_prng_params("pick"))
+def test_prng_pick(c: dict[str, Any]) -> None:
+    assert Prng(c["seed"]).pick(c["key"], c["items"]) == c["result"]
+
+
+@pytest.mark.parametrize("c", **_prng_params("weightedPick"))
+def test_prng_weighted_pick(c: dict[str, Any]) -> None:
+    assert Prng(c["seed"]).weighted_pick(c["key"], c["weights"]) == c["result"]
+
+
+@pytest.mark.parametrize("c", **_prng_params("bool"))
+def test_prng_bool(c: dict[str, Any]) -> None:
+    assert Prng(c["seed"]).bool(c["key"], float(c["likelihood"])) == c["result"]
+
+
+@pytest.mark.parametrize("c", **_prng_params("float"))
+def test_prng_float(c: dict[str, Any]) -> None:
+    assert Prng(c["seed"]).float(c["key"], c["range"]) == float(c["result"])
+
+
+@pytest.mark.parametrize("c", **_prng_params("integer"))
+def test_prng_integer(c: dict[str, Any]) -> None:
+    assert Prng(c["seed"]).integer(c["key"], c["range"]) == c["result"]
+
+
+@pytest.mark.parametrize("c", **_prng_params("shuffle"))
+def test_prng_shuffle(c: dict[str, Any]) -> None:
+    assert Prng(c["seed"]).shuffle(c["key"], c["items"]) == c["result"]
+
+
+# ---------------------------------------------------------------------------
+# Number formatting
+# ---------------------------------------------------------------------------
+
+_NUMBERS = _load("numbers.json")
+
+
+@pytest.mark.parametrize(
+    "entry", _NUMBERS, ids=[f"#{i}-{e['output']}" for i, e in enumerate(_NUMBERS)]
+)
+def test_number_formatting(entry: dict[str, Any]) -> None:
+    assert Number.format(entry["input"]) == entry["output"]
+
+
+# ---------------------------------------------------------------------------
+# Initials
+# ---------------------------------------------------------------------------
+
+_INITIALS = _load("initials.json")
+
+
+@pytest.mark.parametrize(
+    "entry", _INITIALS, ids=[f"#{i}-{e['result']}" for i, e in enumerate(_INITIALS)]
+)
+def test_initials(entry: dict[str, Any]) -> None:
+    assert Initials.from_seed(entry["seed"]) == entry["result"]
+
+
+# ---------------------------------------------------------------------------
+# Avatar
+# ---------------------------------------------------------------------------
+
+
+def _avatar_cases() -> list[tuple[str, dict[str, Any]]]:
+    cases: list[tuple[str, dict[str, Any]]] = []
+
+    for path in sorted((FIXTURES_DIR / "avatars").glob("*.json")):
+        style_name = path.stem
+        for entry in _load(f"avatars/{style_name}.json"):
+            cases.append((style_name, entry))
+
+    return cases
+
+
+_AVATARS = _avatar_cases()
+_STYLE_CACHE: dict[str, Any] = {}
+
+
+@pytest.mark.parametrize(
+    ("style_name", "entry"),
+    _AVATARS,
+    ids=[f"{name}/{entry['id']}" for name, entry in _AVATARS],
+)
+def test_avatar(style_name: str, entry: dict[str, Any]) -> None:
+    style_data = _STYLE_CACHE.setdefault(style_name, _load(f"styles/{style_name}.json"))
+
+    result = Avatar(style_data, entry["options"]).to_json()
+
+    assert result["svg"] == entry["svg"]
+    # Round-trip the resolved options through JSON so int-vs-float typing matches
+    # the JS-generated fixture (Python 1.0 and JS 1 both become JSON 1).
+    assert json.loads(json.dumps(result["options"])) == entry["resolvedOptions"]

--- a/src/python/core/tests/test_prng.py
+++ b/src/python/core/tests/test_prng.py
@@ -1,0 +1,326 @@
+"""Behavioral and edge-case tests for the PRNG.
+
+Known-value vectors (Fnv1a, Mulberry32, get_value) live in
+tests/fixtures/parity/ and are exercised by test_parity.py. This file keeps only
+the Python-side behavioral and edge-case tests.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from dicebear.prng import Fnv1a, Mulberry32, Prng
+
+# ---------------------------------------------------------------------------
+# fnv1a
+# ---------------------------------------------------------------------------
+
+
+def test_fnv1a_produces_different_hashes_for_different_inputs() -> None:
+    assert Fnv1a.hash("abc") != Fnv1a.hash("abd")
+
+
+def test_fnv1a_returns_unsigned_32bit_integers() -> None:
+    for value in ["", "a", "hello", "test:flip", "some-long-seed:optionName"]:
+        h = Fnv1a.hash(value)
+        assert 0 <= h <= 0xFFFFFFFF
+
+
+def test_fnv1a_hex_pads_to_8_characters() -> None:
+    assert len(Fnv1a.hex("test")) == 8
+
+
+# ---------------------------------------------------------------------------
+# mulberry32
+# ---------------------------------------------------------------------------
+
+
+def test_mulberry32_returns_float_in_range() -> None:
+    for seed in [0, 1, 42, 2166136261, 4294967295]:
+        value = Mulberry32(seed).next_float()
+        assert 0 <= value < 1
+
+
+# ---------------------------------------------------------------------------
+# get_value
+# ---------------------------------------------------------------------------
+
+
+def test_get_value_is_deterministic() -> None:
+    assert Prng("seed").get_value("key") == Prng("seed").get_value("key")
+
+
+def test_get_value_differs_for_different_seeds() -> None:
+    assert Prng("seed-a").get_value("key") != Prng("seed-b").get_value("key")
+
+
+def test_get_value_differs_for_different_keys() -> None:
+    prng = Prng("test")
+    assert prng.get_value("flip") != prng.get_value("scale")
+
+
+def test_get_value_returns_float_in_range() -> None:
+    prng = Prng("test")
+    for key in ["a", "b", "flip", "scale", "rotate", "eyesVariant"]:
+        value = prng.get_value(key)
+        assert 0 <= value < 1
+
+
+# ---------------------------------------------------------------------------
+# pick
+# ---------------------------------------------------------------------------
+
+
+def test_pick_returns_none_for_empty_array() -> None:
+    assert Prng("test").pick("key", []) is None
+
+
+def test_pick_returns_single_item() -> None:
+    assert Prng("test").pick("key", ["only"]) == "only"
+
+
+def test_pick_is_deterministic() -> None:
+    items = ["a", "b", "c", "d"]
+    assert Prng("test").pick("key", items) == Prng("test").pick("key", items)
+
+
+def test_pick_always_returns_valid_item() -> None:
+    items = ["x", "y", "z"]
+    for i in range(50):
+        assert Prng(f"seed-{i}").pick("key", items) in items
+
+
+def test_pick_collapses_duplicate_items() -> None:
+    unique = ["a", "b", "c"]
+    with_duplicates = ["a", "a", "b", "b", "b", "c"]
+    for i in range(50):
+        assert Prng(f"seed-{i}").pick("key", unique) == Prng(f"seed-{i}").pick(
+            "key", with_duplicates
+        )
+
+
+def test_pick_treats_all_duplicates_as_single_item() -> None:
+    assert Prng("test").pick("key", ["only", "only", "only"]) == "only"
+
+
+# ---------------------------------------------------------------------------
+# float
+# ---------------------------------------------------------------------------
+
+
+def test_float_returns_value_when_min_equals_max() -> None:
+    assert Prng("test").float("key", {"min": 42, "max": 42}) == pytest.approx(
+        42, abs=1e-10
+    )
+
+
+def test_float_interpolates_within_bounds() -> None:
+    for i in range(50):
+        value = Prng(f"seed-{i}").float("key", {"min": 10, "max": 20})
+        assert 10 <= value <= 20
+
+
+def test_float_handles_reversed_order() -> None:
+    value = Prng("test").float("key", {"min": 20, "max": 10})
+    assert 10 <= value <= 20
+
+
+def test_float_quantizes_to_step() -> None:
+    for i in range(50):
+        value = Prng(f"seed-{i}").float("key", {"min": 0, "max": 100, "step": 5})
+        assert 0 <= value <= 100
+        assert math.fmod(value, 5) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_float_ignores_non_positive_step() -> None:
+    for i in range(20):
+        value = Prng(f"seed-{i}").float("key", {"min": 10, "max": 20, "step": 0})
+        assert 10 <= value <= 20
+
+
+def test_float_step_is_anchored_at_min() -> None:
+    for i in range(50):
+        value = Prng(f"seed-{i}").float("key", {"min": 3, "max": 23, "step": 5})
+        assert 3 <= value <= 23
+        assert math.fmod(value - 3, 5) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_float_reaches_max_endpoint_when_step_divides_range_evenly() -> None:
+    max_seen = False
+    for i in range(500):
+        value = Prng(f"seed-{i}").float("key", {"min": 0, "max": 90, "step": 90})
+        assert value == 0.0 or value == 90.0
+        if value == 90.0:
+            max_seen = True
+    assert max_seen
+
+
+def test_float_is_deterministic() -> None:
+    assert Prng("test").float("key", {"min": 0, "max": 100}) == Prng("test").float(
+        "key", {"min": 0, "max": 100}
+    )
+
+
+def test_float_rounds_to_four_decimal_places() -> None:
+    value = Prng("test").float("scale", {"min": 0, "max": 1})
+    decimals = str(value).split(".")[1] if "." in str(value) else ""
+    assert len(decimals) <= 4
+
+
+# ---------------------------------------------------------------------------
+# bool
+# ---------------------------------------------------------------------------
+
+
+def test_bool_returns_bool() -> None:
+    assert isinstance(Prng("test").bool("key"), bool)
+
+
+def test_bool_always_true_for_likelihood_100() -> None:
+    for i in range(20):
+        assert Prng(f"seed-{i}").bool("key", 100) is True
+
+
+def test_bool_always_false_for_likelihood_0() -> None:
+    for i in range(20):
+        assert Prng(f"seed-{i}").bool("key", 0) is False
+
+
+def test_bool_is_deterministic() -> None:
+    assert Prng("test").bool("key", 50) == Prng("test").bool("key", 50)
+
+
+# ---------------------------------------------------------------------------
+# integer
+# ---------------------------------------------------------------------------
+
+
+def test_integer_returns_value_when_min_equals_max() -> None:
+    assert Prng("test").integer("key", {"min": 5, "max": 5}) == 5
+
+
+def test_integer_within_bounds() -> None:
+    for i in range(50):
+        value = Prng(f"seed-{i}").integer("key", {"min": 1, "max": 10})
+        assert 1 <= value <= 10
+        assert value == math.floor(value)
+
+
+def test_integer_handles_reversed_order() -> None:
+    value = Prng("test").integer("key", {"min": 10, "max": 1})
+    assert 1 <= value <= 10
+
+
+def test_integer_ignores_step() -> None:
+    value = Prng("test").integer("key", {"min": 3, "max": 10, "step": 5})
+    assert 3 <= value <= 10
+    assert value == math.floor(value)
+
+
+def test_integer_is_deterministic() -> None:
+    assert Prng("test").integer("key", {"min": 1, "max": 100}) == Prng("test").integer(
+        "key", {"min": 1, "max": 100}
+    )
+
+
+# ---------------------------------------------------------------------------
+# shuffle
+# ---------------------------------------------------------------------------
+
+
+def test_shuffle_returns_new_array() -> None:
+    items = [1, 2, 3, 4, 5]
+    result = Prng("test").shuffle("key", items)
+    assert result is not items
+
+
+def test_shuffle_contains_same_elements() -> None:
+    items = [1, 2, 3, 4, 5]
+    result = Prng("test").shuffle("key", items)
+    assert sorted(result) == sorted(items)
+
+
+def test_shuffle_does_not_modify_original() -> None:
+    items = [1, 2, 3, 4, 5]
+    copy_ = list(items)
+    Prng("test").shuffle("key", items)
+    assert items == copy_
+
+
+def test_shuffle_is_deterministic() -> None:
+    items = list(range(1, 11))
+    assert Prng("test").shuffle("key", items) == Prng("test").shuffle("key", items)
+
+
+def test_shuffle_produces_different_orderings_for_different_keys() -> None:
+    items = list(range(1, 11))
+    prng = Prng("test")
+    assert prng.shuffle("key-a", items) != prng.shuffle("key-b", items)
+
+
+def test_shuffle_handles_empty_array() -> None:
+    assert Prng("test").shuffle("key", []) == []
+
+
+def test_shuffle_handles_single_element() -> None:
+    assert Prng("test").shuffle("key", [42]) == [42]
+
+
+def test_shuffle_collapses_duplicates() -> None:
+    result = Prng("test").shuffle("key", ["a", "a", "b", "b", "c", "c"])
+    assert sorted(result) == ["a", "b", "c"]
+
+
+# ---------------------------------------------------------------------------
+# weighted_pick
+# ---------------------------------------------------------------------------
+
+
+def test_weighted_pick_returns_none_for_empty_map() -> None:
+    assert Prng("test").weighted_pick("key", {}) is None
+
+
+def test_weighted_pick_returns_single_key() -> None:
+    assert Prng("test").weighted_pick("key", {"only": 1}) == "only"
+
+
+def test_weighted_pick_falls_back_to_uniform_when_all_weights_zero() -> None:
+    result = Prng("test").weighted_pick("key", {"a": 0, "b": 0, "c": 0})
+    assert result in ["a", "b", "c"]
+
+
+def test_weighted_pick_is_deterministic() -> None:
+    weights = {"a": 1, "b": 5, "c": 2}
+    assert Prng("test").weighted_pick("key", weights) == Prng("test").weighted_pick(
+        "key", weights
+    )
+
+
+def test_weighted_pick_never_picks_weight_zero_key() -> None:
+    weights = {"rare": 0, "common": 1}
+    for i in range(100):
+        assert Prng(f"seed-{i}").weighted_pick("key", weights) == "common"
+
+
+def test_weighted_pick_favors_higher_weighted_keys() -> None:
+    weights = {"heavy": 100, "light": 1}
+    heavy_count = sum(
+        1
+        for i in range(200)
+        if Prng(f"seed-{i}").weighted_pick("key", weights) == "heavy"
+    )
+    assert heavy_count > 150
+
+
+def test_weighted_pick_produces_insertion_order_independent_results() -> None:
+    result_a = Prng("test").weighted_pick("key", {"x": 1, "y": 5, "z": 2})
+    result_b = Prng("test").weighted_pick("key", {"z": 2, "x": 1, "y": 5})
+    assert result_a == result_b
+
+
+def test_weighted_pick_always_returns_valid_key() -> None:
+    weights = {"a": 1, "b": 1, "c": 1}
+    for i in range(50):
+        assert Prng(f"seed-{i}").weighted_pick("key", weights) in ["a", "b", "c"]

--- a/src/python/core/tests/test_renderer.py
+++ b/src/python/core/tests/test_renderer.py
@@ -1,0 +1,1048 @@
+"""Tests for SVG rendering (driven through Avatar)."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from dicebear import Avatar, Style
+
+
+def _minimal_style() -> Style:
+    return Style({"canvas": {"width": 100, "height": 100, "elements": []}})
+
+
+def _style_with_components() -> Style:
+    return Style(
+        {
+            "canvas": {
+                "width": 100,
+                "height": 100,
+                "elements": [{"type": "component", "name": "eyes"}],
+            },
+            "components": {
+                "eyes": {
+                    "width": 50,
+                    "height": 50,
+                    "variants": {
+                        "open": {
+                            "elements": [
+                                {
+                                    "type": "element",
+                                    "name": "circle",
+                                    "attributes": {"r": "5"},
+                                }
+                            ]
+                        },
+                        "closed": {
+                            "elements": [
+                                {
+                                    "type": "element",
+                                    "name": "line",
+                                    "attributes": {"x1": "0", "x2": "10"},
+                                }
+                            ]
+                        },
+                    },
+                }
+            },
+        }
+    )
+
+
+def _style_with_ids() -> Style:
+    return Style(
+        {
+            "canvas": {
+                "width": 100,
+                "height": 100,
+                "elements": [
+                    {
+                        "type": "element",
+                        "name": "defs",
+                        "children": [
+                            {
+                                "type": "element",
+                                "name": "linearGradient",
+                                "attributes": {"id": "grad1"},
+                                "children": [
+                                    {
+                                        "type": "element",
+                                        "name": "stop",
+                                        "attributes": {
+                                            "offset": "0%",
+                                            "stop-color": "red",
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "type": "element",
+                        "name": "rect",
+                        "attributes": {"fill": "url(#grad1)"},
+                    },
+                ],
+            }
+        }
+    )
+
+
+def _style_with_component(extras: dict[str, Any] | None = None) -> Style:
+    eyes: dict[str, Any] = {"width": 50, "height": 50}
+    eyes.update(extras or {})
+    eyes["variants"] = {"open": {"elements": [{"type": "element", "name": "rect"}]}}
+
+    return Style(
+        {
+            "canvas": {
+                "width": 100,
+                "height": 100,
+                "elements": [{"type": "component", "name": "eyes"}],
+            },
+            "components": {"eyes": eyes},
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# SVG wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_svg_with_view_box() -> None:
+    svg = Avatar(_minimal_style()).to_string()
+    assert svg.startswith("<svg ")
+    assert 'xmlns="http://www.w3.org/2000/svg"' in svg
+    assert 'viewBox="0 0 100 100"' in svg
+    assert svg.endswith("</svg>")
+
+
+def test_title_sets_role_img_and_aria_label() -> None:
+    svg = Avatar(_minimal_style(), {"title": "Test Avatar"}).to_string()
+    assert 'role="img"' in svg
+    assert 'aria-label="Test Avatar"' in svg
+    assert "<title>Test Avatar</title>" in svg
+
+
+def test_title_escaped() -> None:
+    svg = Avatar(_minimal_style(), {"title": "A & B <C>"}).to_string()
+    assert 'aria-label="A &amp; B &lt;C&gt;"' in svg
+    assert "<title>A &amp; B &lt;C&gt;</title>" in svg
+
+
+def test_aria_hidden_without_title() -> None:
+    svg = Avatar(_minimal_style()).to_string()
+    assert 'aria-hidden="true"' in svg
+    assert 'role="img"' not in svg
+    assert "<title>" not in svg
+
+
+def test_size_included_when_set() -> None:
+    svg = Avatar(_minimal_style(), {"size": 64}).to_string()
+    assert 'width="64"' in svg
+    assert 'height="64"' in svg
+
+
+def test_size_not_included_when_not_set() -> None:
+    svg = Avatar(_minimal_style()).to_string()
+    open_tag = svg[: svg.index(">") + 1]
+    assert "width=" not in open_tag
+    assert "height=" not in open_tag
+
+
+# ---------------------------------------------------------------------------
+# element rendering
+# ---------------------------------------------------------------------------
+
+
+def test_self_closing_elements() -> None:
+    style = Style(
+        {
+            "canvas": {
+                "width": 100,
+                "height": 100,
+                "elements": [
+                    {
+                        "type": "element",
+                        "name": "rect",
+                        "attributes": {
+                            "x": "0",
+                            "y": "0",
+                            "width": "100",
+                            "height": "100",
+                        },
+                    }
+                ],
+            }
+        }
+    )
+    svg = Avatar(style).to_string()
+    assert '<rect x="0" y="0" width="100" height="100"/>' in svg
+
+
+def test_elements_with_children() -> None:
+    style = Style(
+        {
+            "canvas": {
+                "width": 100,
+                "height": 100,
+                "elements": [
+                    {
+                        "type": "element",
+                        "name": "g",
+                        "children": [
+                            {
+                                "type": "element",
+                                "name": "circle",
+                                "attributes": {"cx": "50", "cy": "50", "r": "10"},
+                            }
+                        ],
+                    }
+                ],
+            }
+        }
+    )
+    svg = Avatar(style).to_string()
+    assert '<g><circle cx="50" cy="50" r="10"/></g>' in svg
+
+
+def test_nested_elements() -> None:
+    style = Style(
+        {
+            "canvas": {
+                "width": 100,
+                "height": 100,
+                "elements": [
+                    {
+                        "type": "element",
+                        "name": "g",
+                        "attributes": {"id": "outer"},
+                        "children": [
+                            {
+                                "type": "element",
+                                "name": "g",
+                                "attributes": {"id": "inner"},
+                                "children": [{"type": "element", "name": "rect"}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        }
+    )
+    svg = Avatar(style).to_string()
+    assert '<g id="outer"><g id="inner"><rect/></g></g>' in svg
+
+
+# ---------------------------------------------------------------------------
+# text rendering
+# ---------------------------------------------------------------------------
+
+
+def _text_style(value: Any) -> Style:
+    return Style(
+        {
+            "canvas": {
+                "width": 100,
+                "height": 100,
+                "elements": [
+                    {
+                        "type": "element",
+                        "name": "text",
+                        "children": [{"type": "text", "value": value}],
+                    }
+                ],
+            }
+        }
+    )
+
+
+def test_text_content() -> None:
+    svg = Avatar(_text_style("Hello")).to_string()
+    assert "<text>Hello</text>" in svg
+
+
+def test_variable_reference_initial() -> None:
+    svg = Avatar(
+        _text_style({"type": "variable", "name": "initial"}), {"seed": "Alice"}
+    ).to_string()
+    assert "<text>A</text>" in svg
+
+
+def test_initials_multi_word() -> None:
+    svg = Avatar(
+        _text_style({"type": "variable", "name": "initials"}), {"seed": "Alice Bob"}
+    ).to_string()
+    assert "<text>AB</text>" in svg
+
+
+def test_initials_single_word() -> None:
+    svg = Avatar(
+        _text_style({"type": "variable", "name": "initials"}), {"seed": "Alice"}
+    ).to_string()
+    assert "<text>AL</text>" in svg
+
+
+def test_initials_discard_at_symbol() -> None:
+    svg = Avatar(
+        _text_style({"type": "variable", "name": "initials"}),
+        {"seed": "alice@example.com"},
+    ).to_string()
+    assert "<text>AL</text>" in svg
+
+
+# ---------------------------------------------------------------------------
+# component rendering
+# ---------------------------------------------------------------------------
+
+
+def test_renders_selected_variant() -> None:
+    svg = Avatar(
+        _style_with_components(), {"seed": "test", "eyesVariant": "open"}
+    ).to_string()
+    assert '<circle r="5"/>' in svg
+    assert "<line" not in svg
+
+
+def test_registers_variant_body_in_defs_and_references_it_via_use() -> None:
+    svg = Avatar(
+        _style_with_components(), {"seed": "test", "eyesVariant": "open"}
+    ).to_string()
+    match = re.search(r'<g id="(eyes-open-[a-f0-9]+)"><circle r="5"/></g>', svg)
+    assert match is not None
+    assert "<defs>" in svg
+    assert f'<use href="#{match.group(1)}"/>' in svg
+
+
+def test_skips_component_with_probability_zero() -> None:
+    svg = Avatar(
+        _style_with_components(), {"seed": "test", "eyesProbability": 0}
+    ).to_string()
+    assert "<circle" not in svg
+    assert "<line" not in svg
+    assert "<use" not in svg
+
+
+def test_component_transforms_from_definition() -> None:
+    style = Style(
+        {
+            "canvas": {
+                "width": 100,
+                "height": 100,
+                "elements": [{"type": "component", "name": "eyes"}],
+            },
+            "components": {
+                "eyes": {
+                    "width": 50,
+                    "height": 50,
+                    "translate": {
+                        "x": {"min": 5, "max": 5},
+                        "y": {"min": 10, "max": 10},
+                    },
+                    "variants": {
+                        "open": {
+                            "elements": [
+                                {
+                                    "type": "element",
+                                    "name": "circle",
+                                    "attributes": {"r": "5"},
+                                }
+                            ]
+                        }
+                    },
+                }
+            },
+        }
+    )
+    svg = Avatar(style, {"seed": "test"}).to_string()
+    assert '<use transform="translate(2.5, 5)" href="#eyes-open-' in svg
+
+
+def test_component_rotation_from_definition_with_center() -> None:
+    style = Style(
+        {
+            "canvas": {
+                "width": 100,
+                "height": 100,
+                "elements": [{"type": "component", "name": "eyes"}],
+            },
+            "components": {
+                "eyes": {
+                    "width": 50,
+                    "height": 50,
+                    "rotate": {"min": 45, "max": 45},
+                    "variants": {
+                        "open": {
+                            "elements": [
+                                {
+                                    "type": "element",
+                                    "name": "circle",
+                                    "attributes": {"r": "5"},
+                                }
+                            ]
+                        }
+                    },
+                }
+            },
+        }
+    )
+    svg = Avatar(style, {"seed": "test"}).to_string()
+    assert '<use transform="rotate(45, 25, 25)" href="#eyes-open-' in svg
+
+
+def test_omits_transform_attribute_without_component_transforms() -> None:
+    svg = Avatar(
+        _style_with_components(), {"seed": "test", "eyesVariant": "open"}
+    ).to_string()
+    assert '<use href="#eyes-open-' in svg
+    assert re.search(r"<use[^>]*\btransform=", svg) is None
+
+
+def test_applies_attributes_from_component_reference_to_use_tag() -> None:
+    style = Style(
+        {
+            "canvas": {
+                "width": 100,
+                "height": 100,
+                "elements": [
+                    {
+                        "type": "component",
+                        "name": "eyes",
+                        "attributes": {
+                            "transform": "matrix(.5 0 0 .5 10 20)",
+                            "opacity": ".75",
+                        },
+                    }
+                ],
+            },
+            "components": {
+                "eyes": {
+                    "width": 50,
+                    "height": 50,
+                    "variants": {
+                        "open": {
+                            "elements": [
+                                {
+                                    "type": "element",
+                                    "name": "circle",
+                                    "attributes": {"r": "5"},
+                                }
+                            ]
+                        }
+                    },
+                }
+            },
+        }
+    )
+    svg = Avatar(style, {"seed": "test", "eyesVariant": "open"}).to_string()
+    assert (
+        '<use transform="matrix(.5 0 0 .5 10 20)" opacity=".75" href="#eyes-open-'
+        in svg
+    )
+
+
+def test_prepends_user_transform_to_built_in_component_transforms() -> None:
+    style = Style(
+        {
+            "canvas": {
+                "width": 100,
+                "height": 100,
+                "elements": [
+                    {
+                        "type": "component",
+                        "name": "eyes",
+                        "attributes": {"transform": "matrix(.5 0 0 .5 10 20)"},
+                    }
+                ],
+            },
+            "components": {
+                "eyes": {
+                    "width": 50,
+                    "height": 50,
+                    "rotate": {"min": 45, "max": 45},
+                    "variants": {
+                        "open": {
+                            "elements": [
+                                {
+                                    "type": "element",
+                                    "name": "circle",
+                                    "attributes": {"r": "5"},
+                                }
+                            ]
+                        }
+                    },
+                }
+            },
+        }
+    )
+    svg = Avatar(style, {"seed": "test"}).to_string()
+    assert (
+        '<use transform="matrix(.5 0 0 .5 10 20) rotate(45, 25, 25)" href="#eyes-open-'
+        in svg
+    )
+
+
+def test_deduplicates_identical_component_references() -> None:
+    style = Style(
+        {
+            "canvas": {
+                "width": 100,
+                "height": 100,
+                "elements": [
+                    {"type": "component", "name": "eyes"},
+                    {"type": "component", "name": "eyes"},
+                ],
+            },
+            "components": {
+                "eyes": {
+                    "width": 50,
+                    "height": 50,
+                    "variants": {
+                        "open": {
+                            "elements": [
+                                {
+                                    "type": "element",
+                                    "name": "circle",
+                                    "attributes": {"r": "5"},
+                                }
+                            ]
+                        }
+                    },
+                }
+            },
+        }
+    )
+    svg = Avatar(style, {"seed": "test", "eyesVariant": "open"}).to_string()
+    assert len(re.findall(r'<circle r="5"/>', svg)) == 1
+    assert len(re.findall(r'<use href="#eyes-open-[a-f0-9]+"/>', svg)) == 2
+
+
+# ---------------------------------------------------------------------------
+# color rendering
+# ---------------------------------------------------------------------------
+
+
+def test_solid_color_reference() -> None:
+    style = Style(
+        {
+            "canvas": {
+                "width": 100,
+                "height": 100,
+                "elements": [
+                    {
+                        "type": "element",
+                        "name": "rect",
+                        "attributes": {"fill": {"type": "color", "name": "bg"}},
+                    }
+                ],
+            },
+            "colors": {"bg": {"values": ["#ff0000"]}},
+        }
+    )
+    svg = Avatar(style, {"seed": "test", "bgColor": ["#ff0000"]}).to_string()
+    assert 'fill="#ff0000"' in svg
+
+
+def test_linear_gradient() -> None:
+    style = Style(
+        {
+            "canvas": {
+                "width": 100,
+                "height": 100,
+                "elements": [
+                    {
+                        "type": "element",
+                        "name": "rect",
+                        "attributes": {"fill": {"type": "color", "name": "bg"}},
+                    }
+                ],
+            },
+            "colors": {"bg": {"values": ["#ff0000", "#0000ff"]}},
+        }
+    )
+    svg = Avatar(
+        style,
+        {"seed": "test", "bgColor": ["#ff0000", "#0000ff"], "bgColorFill": "linear"},
+    ).to_string()
+    assert "<defs>" in svg
+    assert '<linearGradient id="bg-color-' in svg
+    assert 'stop-color="#ff0000"' in svg
+    assert 'stop-color="#0000ff"' in svg
+    assert 'fill="url(#bg-color-' in svg
+
+
+def test_radial_gradient() -> None:
+    style = Style(
+        {
+            "canvas": {
+                "width": 100,
+                "height": 100,
+                "elements": [
+                    {
+                        "type": "element",
+                        "name": "rect",
+                        "attributes": {"fill": {"type": "color", "name": "bg"}},
+                    }
+                ],
+            },
+            "colors": {"bg": {"values": ["#ff0000", "#0000ff"]}},
+        }
+    )
+    svg = Avatar(
+        style,
+        {"seed": "test", "bgColor": ["#ff0000", "#0000ff"], "bgColorFill": "radial"},
+    ).to_string()
+    assert '<radialGradient id="bg-color-' in svg
+
+
+# ---------------------------------------------------------------------------
+# flip
+# ---------------------------------------------------------------------------
+
+
+def test_horizontal_flip() -> None:
+    svg = Avatar(_minimal_style(), {"flip": "horizontal"}).to_string()
+    assert "scale(-1, 1)" in svg
+    assert "translate(100, 0)" in svg
+
+
+def test_vertical_flip() -> None:
+    svg = Avatar(_minimal_style(), {"flip": "vertical"}).to_string()
+    assert "scale(1, -1)" in svg
+    assert "translate(0, 100)" in svg
+
+
+def test_both_flip() -> None:
+    svg = Avatar(_minimal_style(), {"flip": "both"}).to_string()
+    assert "scale(-1, -1)" in svg
+    assert "translate(100, 100)" in svg
+
+
+def test_no_flip_when_none() -> None:
+    svg = Avatar(_minimal_style(), {"flip": "none"}).to_string()
+    assert "scale(-1" not in svg
+
+
+# ---------------------------------------------------------------------------
+# scale
+# ---------------------------------------------------------------------------
+
+
+def test_scale_transform() -> None:
+    svg = Avatar(_minimal_style(), {"scale": 0.5}).to_string()
+    assert "scale(0.5)" in svg
+    assert "translate(50, 50)" in svg
+    assert "translate(-50, -50)" in svg
+
+
+def test_no_scale_when_1() -> None:
+    svg = Avatar(_minimal_style(), {"scale": 1}).to_string()
+    assert "scale(" not in svg
+
+
+# ---------------------------------------------------------------------------
+# component scale
+# ---------------------------------------------------------------------------
+
+
+def test_component_scale_from_definition() -> None:
+    svg = Avatar(
+        _style_with_component({"scale": {"min": 2, "max": 2}}), {"seed": "test"}
+    ).to_string()
+    assert "translate(25, 25) scale(2) translate(-25, -25)" in svg
+
+
+def test_no_component_scale_wrapper_when_definition_is_one() -> None:
+    svg = Avatar(_style_with_component(), {"seed": "test"}).to_string()
+    assert "scale(" not in svg
+
+
+def test_component_scale_after_rotate_in_transform_attribute() -> None:
+    svg = Avatar(
+        _style_with_component(
+            {"rotate": {"min": 45, "max": 45}, "scale": {"min": 2, "max": 2}}
+        ),
+        {"seed": "test"},
+    ).to_string()
+    rotate_index = svg.find("rotate(45")
+    scale_index = svg.find("scale(2)")
+    assert rotate_index != -1
+    assert scale_index != -1
+    assert rotate_index < scale_index
+
+
+# ---------------------------------------------------------------------------
+# borderRadius
+# ---------------------------------------------------------------------------
+
+
+def test_border_radius_via_clip_path() -> None:
+    svg = Avatar(_minimal_style(), {"borderRadius": 10}).to_string()
+    assert '<clipPath id="clip-' in svg
+    assert 'rx="10"' in svg
+    assert 'ry="10"' in svg
+    assert 'clip-path="url(#clip-' in svg
+
+
+def test_still_applies_square_clip_path_when_border_radius_is_0() -> None:
+    svg = Avatar(_minimal_style(), {"borderRadius": 0}).to_string()
+    assert '<clipPath id="clip-' in svg
+    assert 'rx="0"' in svg
+    assert 'ry="0"' in svg
+    assert 'clip-path="url(#clip-' in svg
+
+
+# ---------------------------------------------------------------------------
+# idRandomization
+# ---------------------------------------------------------------------------
+
+
+def test_randomize_ids_when_enabled() -> None:
+    svg = Avatar(
+        _style_with_ids(), {"seed": "test", "idRandomization": True}
+    ).to_string()
+    assert 'id="grad1"' not in svg
+    assert "url(#grad1)" not in svg
+    assert 'id="grad1-' in svg
+    assert "url(#grad1-" in svg
+
+
+def test_preserve_ids_when_disabled() -> None:
+    svg = Avatar(
+        _style_with_ids(), {"seed": "test", "idRandomization": False}
+    ).to_string()
+    assert 'id="grad1"' in svg
+    assert "url(#grad1)" in svg
+
+
+def test_different_ids_on_each_call() -> None:
+    svg1 = Avatar(
+        _style_with_ids(), {"seed": "test", "idRandomization": True}
+    ).to_string()
+    svg2 = Avatar(
+        _style_with_ids(), {"seed": "test", "idRandomization": True}
+    ).to_string()
+    assert svg1 != svg2
+
+
+# ---------------------------------------------------------------------------
+# background
+# ---------------------------------------------------------------------------
+
+
+def test_solid_background() -> None:
+    svg = Avatar(_minimal_style(), {"backgroundColor": ["#ff0000"]}).to_string()
+    assert '<rect width="100" height="100" fill="#ff0000"/>' in svg
+
+
+def test_gradient_background() -> None:
+    svg = Avatar(
+        _minimal_style(),
+        {"backgroundColor": ["#ff0000", "#0000ff"], "backgroundColorFill": "linear"},
+    ).to_string()
+    assert '<linearGradient id="background-color-' in svg
+    assert 'fill="url(#background-color-' in svg
+
+
+def test_gradient_rotation() -> None:
+    svg = Avatar(
+        _minimal_style(),
+        {
+            "backgroundColor": ["#ff0000", "#0000ff"],
+            "backgroundColorFill": "linear",
+            "backgroundColorAngle": 45,
+        },
+    ).to_string()
+    assert 'gradientTransform="rotate(45, 0.5, 0.5)"' in svg
+
+
+def test_no_background_without_colors() -> None:
+    svg = Avatar(_minimal_style()).to_string()
+    # The clipPath wrapper always emits a <rect>; only the background <rect>
+    # carries a fill attribute, so check for that specifically.
+    assert re.search(r"<rect[^>]*\sfill=", svg) is None
+
+
+# ---------------------------------------------------------------------------
+# global transforms
+# ---------------------------------------------------------------------------
+
+
+def test_global_rotation() -> None:
+    svg = Avatar(_minimal_style(), {"rotate": 45}).to_string()
+    assert "rotate(45, 50, 50)" in svg
+
+
+def test_no_rotation_when_0() -> None:
+    svg = Avatar(_minimal_style(), {"rotate": 0}).to_string()
+    assert "rotate(" not in svg
+
+
+def test_global_translate() -> None:
+    svg = Avatar(_minimal_style(), {"translateX": 10, "translateY": -20}).to_string()
+    assert "translate(10, -20)" in svg
+
+
+# ---------------------------------------------------------------------------
+# metadata
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_with_dublin_core() -> None:
+    style = Style(
+        {
+            "canvas": {"width": 100, "height": 100, "elements": []},
+            "meta": {
+                "creator": {"name": "John Doe"},
+                "source": {"name": "My Style", "url": "https://example.com"},
+                "license": {
+                    "name": "MIT",
+                    "url": "https://opensource.org/licenses/MIT",
+                },
+            },
+        }
+    )
+    svg = Avatar(style).to_string()
+    assert "<metadata" in svg
+    assert "<dc:title>My Style</dc:title>" in svg
+    assert "<dc:creator>John Doe</dc:creator>" in svg
+
+
+def test_no_metadata_when_no_meta() -> None:
+    svg = Avatar(_minimal_style()).to_string()
+    assert "<metadata" not in svg
+
+
+def test_remix_of_prefix() -> None:
+    style = Style(
+        {
+            "canvas": {"width": 100, "height": 100, "elements": []},
+            "meta": {
+                "creator": {"name": "Pablo Stanley"},
+                "source": {"name": "Avataaars", "url": "https://avataaars.com"},
+                "license": {
+                    "name": "CC BY 4.0",
+                    "url": "https://creativecommons.org/licenses/by/4.0/",
+                },
+            },
+        }
+    )
+    svg = Avatar(style).to_string()
+    assert "Remix of" in svg
+    assert "Avataaars" in svg
+
+
+def test_no_remix_of_for_mit_dicebear() -> None:
+    style = Style(
+        {
+            "canvas": {"width": 100, "height": 100, "elements": []},
+            "meta": {
+                "creator": {"name": "DiceBear"},
+                "source": {"name": "Initials"},
+                "license": {"name": "MIT"},
+            },
+        }
+    )
+    svg = Avatar(style).to_string()
+    assert "Remix of" not in svg
+    assert "Initials" in svg
+
+
+def test_xml_escaping_in_metadata() -> None:
+    style = Style(
+        {
+            "canvas": {"width": 100, "height": 100, "elements": []},
+            "meta": {
+                "creator": {"name": "A & B"},
+                "source": {"name": "<Script>"},
+                "license": {"name": "MIT"},
+            },
+        }
+    )
+    svg = Avatar(style).to_string()
+    assert "A &amp; B" in svg
+    assert "&lt;Script&gt;" in svg
+
+
+# ---------------------------------------------------------------------------
+# variable attributes
+# ---------------------------------------------------------------------------
+
+
+def test_font_family_variable() -> None:
+    style = Style(
+        {
+            "canvas": {
+                "width": 100,
+                "height": 100,
+                "elements": [
+                    {
+                        "type": "element",
+                        "name": "text",
+                        "attributes": {
+                            "font-family": {"type": "variable", "name": "fontFamily"}
+                        },
+                        "children": [{"type": "text", "value": "Hello"}],
+                    }
+                ],
+            }
+        }
+    )
+    svg = Avatar(style, {"fontFamily": "Arial"}).to_string()
+    assert 'font-family="Arial"' in svg
+
+
+def test_font_weight_variable() -> None:
+    style = Style(
+        {
+            "canvas": {
+                "width": 100,
+                "height": 100,
+                "elements": [
+                    {
+                        "type": "element",
+                        "name": "text",
+                        "attributes": {
+                            "font-weight": {"type": "variable", "name": "fontWeight"}
+                        },
+                        "children": [{"type": "text", "value": "Hello"}],
+                    }
+                ],
+            }
+        }
+    )
+    svg = Avatar(style, {"fontWeight": 700}).to_string()
+    assert 'font-weight="700"' in svg
+
+
+def test_plain_string_font_family() -> None:
+    style = Style(
+        {
+            "canvas": {
+                "width": 100,
+                "height": 100,
+                "elements": [
+                    {
+                        "type": "element",
+                        "name": "text",
+                        "attributes": {"font-family": "monospace"},
+                        "children": [{"type": "text", "value": "Hello"}],
+                    }
+                ],
+            }
+        }
+    )
+    svg = Avatar(style).to_string()
+    assert 'font-family="monospace"' in svg
+
+
+# ---------------------------------------------------------------------------
+# xml escaping
+# ---------------------------------------------------------------------------
+
+
+def test_escape_attribute_values() -> None:
+    style = Style(
+        {
+            "canvas": {
+                "width": 100,
+                "height": 100,
+                "elements": [
+                    {
+                        "type": "element",
+                        "name": "rect",
+                        "attributes": {"d": 'a & b "c"'},
+                    }
+                ],
+            }
+        }
+    )
+    svg = Avatar(style).to_string()
+    assert 'd="a &amp; b &quot;c&quot;"' in svg
+
+
+def test_escape_text_content() -> None:
+    svg = Avatar(_text_style('<script>alert("xss")</script>')).to_string()
+    assert "<script>" not in svg
+    assert "&lt;script&gt;" in svg
+
+
+# ---------------------------------------------------------------------------
+# component aliases
+# ---------------------------------------------------------------------------
+
+
+def _alias_style() -> Style:
+    return Style(
+        {
+            "canvas": {
+                "width": 100,
+                "height": 100,
+                "elements": [
+                    {"type": "component", "name": "eyes"},
+                    {"type": "component", "name": "eyesRight"},
+                ],
+            },
+            "components": {
+                "eyes": {
+                    "width": 20,
+                    "height": 20,
+                    "variants": {
+                        v: {
+                            "elements": [
+                                {
+                                    "type": "element",
+                                    "name": "circle",
+                                    "attributes": {"id": v},
+                                }
+                            ]
+                        }
+                        for v in ["a", "b", "c", "d", "e"]
+                    },
+                },
+                "eyesRight": {"extends": "eyes"},
+            },
+        }
+    )
+
+
+def test_alias_gets_independent_variant_per_seed() -> None:
+    differed = False
+    for seed in ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]:
+        svg = Avatar(_alias_style(), {"seed": seed}).to_string()
+        matches = re.findall(r'<circle id="([a-z])"/>', svg)
+        if len(matches) == 2 and matches[0] != matches[1]:
+            differed = True
+            break
+    assert differed
+
+
+def test_alias_inherits_eyes_variant_and_shares_defs_entry() -> None:
+    svg = Avatar(
+        _alias_style(), {"seed": "fallthrough", "eyesVariant": "b"}
+    ).to_string()
+    circles = re.findall(r'<circle id="([a-z])"/>', svg)
+    uses = re.findall(r'<use href="#(eyes-[a-z]-[a-f0-9]+)"/>', svg)
+    assert circles == ["b"]
+    assert len(uses) == 2
+    assert uses[0] == uses[1]
+
+
+def test_alias_propagates_eyes_probability() -> None:
+    svg = Avatar(
+        _alias_style(), {"seed": "probability-fallthrough", "eyesProbability": 0}
+    ).to_string()
+    assert "<circle" not in svg
+
+
+def test_alias_silently_ignores_alias_keyed_options() -> None:
+    without = Avatar(
+        _alias_style(), {"seed": "ignore-alias-key", "eyesVariant": "a"}
+    ).to_string()
+    with_ = Avatar(
+        _alias_style(),
+        {"seed": "ignore-alias-key", "eyesVariant": "a", "eyesRightVariant": "d"},
+    ).to_string()
+    assert without == with_

--- a/src/python/core/tests/test_resolver.py
+++ b/src/python/core/tests/test_resolver.py
@@ -1,0 +1,713 @@
+"""Tests for deterministic option resolution."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from dicebear import Style
+from dicebear.errors import CircularColorReferenceError
+from dicebear.options import Options
+from dicebear.resolver import Resolver
+
+
+def _make_resolver(style: Style, data: dict[str, Any] | None = None) -> Resolver:
+    return Resolver(style, Options(data or {}))
+
+
+def _minimal_style() -> Style:
+    return Style({"canvas": {"width": 100, "height": 100, "elements": []}})
+
+
+def _style_with_components() -> Style:
+    return Style(
+        {
+            "canvas": {"width": 100, "height": 100, "elements": []},
+            "components": {
+                "eyes": {
+                    "width": 50,
+                    "height": 50,
+                    "variants": {
+                        "open": {"elements": []},
+                        "closed": {"elements": []},
+                        "wink": {"elements": []},
+                    },
+                }
+            },
+        }
+    )
+
+
+def _style_with_colors() -> Style:
+    return Style(
+        {
+            "canvas": {"width": 100, "height": 100, "elements": []},
+            "colors": {
+                "skin": {"values": ["#f0c8a0", "#d4a574", "#8d5524"]},
+                "hair": {
+                    "values": ["#2c1b18", "#b55239", "#d6b370"],
+                    "notEqualTo": ["skin"],
+                },
+                "background": {
+                    "values": ["#ffffff", "#000000", "#cccccc"],
+                    "contrastTo": "skin",
+                },
+            },
+        }
+    )
+
+
+def _style_with_weights() -> Style:
+    return Style(
+        {
+            "canvas": {"width": 100, "height": 100, "elements": []},
+            "components": {
+                "eyes": {
+                    "width": 50,
+                    "height": 50,
+                    "variants": {
+                        "common": {"elements": [], "weight": 10},
+                        "rare": {"elements": [], "weight": 1},
+                        "hidden": {"elements": [], "weight": 0},
+                    },
+                }
+            },
+        }
+    )
+
+
+def _full_options() -> dict[str, Any]:
+    return {
+        "seed": "test-seed",
+        "size": 128,
+        "idRandomization": True,
+        "flip": ["horizontal", "vertical"],
+        "fontFamily": ["Arial", "Helvetica"],
+        "fontWeight": [400, 700],
+        "scale": [0.8, 1.2],
+        "borderRadius": [0, 50],
+        "eyesProbability": 80,
+        "eyesVariant": ["open", "closed", "wink"],
+        "skinColor": ["#f0c8a0", "#d4a574"],
+        "rotate": [-15, 15],
+        "translateX": [-5, 5],
+        "translateY": [-2, 2],
+    }
+
+
+# ---------------------------------------------------------------------------
+# constructor
+# ---------------------------------------------------------------------------
+
+
+def test_accepts_minimal_options() -> None:
+    assert _make_resolver(_minimal_style(), {}) is not None
+
+
+def test_accepts_full_options() -> None:
+    assert _make_resolver(_minimal_style(), _full_options()) is not None
+
+
+# ---------------------------------------------------------------------------
+# defaults
+# ---------------------------------------------------------------------------
+
+
+def test_defaults() -> None:
+    resolver = _make_resolver(_minimal_style(), {})
+    assert resolver.seed() == ""
+    assert resolver.size() is None
+    assert resolver.id_randomization() is False
+    assert resolver.flip() == "none"
+    assert resolver.font_family() == "system-ui"
+    assert resolver.font_weight() == 400
+    assert resolver.scale() == pytest.approx(1, abs=1e-10)
+    assert resolver.border_radius() == pytest.approx(0, abs=1e-10)
+
+
+def test_pattern_defaults() -> None:
+    resolver = _make_resolver(_minimal_style(), {})
+    assert resolver.variant("eyes") is None
+    assert resolver.color("skin") == []
+    assert resolver.color_fill("skin") == "solid"
+    assert resolver.rotate() == pytest.approx(0, abs=1e-10)
+    assert resolver.translate_x() == pytest.approx(0, abs=1e-10)
+    assert resolver.translate_y() == pytest.approx(0, abs=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# single values
+# ---------------------------------------------------------------------------
+
+
+def test_single_values() -> None:
+    resolver = _make_resolver(
+        _minimal_style(),
+        {
+            "seed": "my-seed",
+            "size": 256,
+            "idRandomization": True,
+            "flip": "horizontal",
+            "fontFamily": "Arial",
+            "fontWeight": 700,
+            "scale": 1.5,
+            "borderRadius": 25,
+        },
+    )
+    assert resolver.seed() == "my-seed"
+    assert resolver.size() == 256
+    assert resolver.id_randomization() is True
+    assert resolver.flip() == "horizontal"
+    assert resolver.font_family() == "Arial"
+    assert resolver.font_weight() == 700
+    assert resolver.scale() == pytest.approx(1.5, abs=1e-10)
+    assert resolver.border_radius() == pytest.approx(25, abs=1e-10)
+
+
+def test_single_pattern_values() -> None:
+    resolver = _make_resolver(
+        _minimal_style(),
+        {
+            "eyesProbability": 80,
+            "eyesVariant": "open",
+            "skinColor": "#f0c8a0",
+            "rotate": 45,
+            "translateX": 5,
+            "translateY": -3,
+        },
+    )
+    assert resolver.variant("eyes") is None
+    assert resolver.color("skin") == ["#f0c8a0"]
+    assert resolver.rotate() == pytest.approx(45, abs=1e-10)
+    assert resolver.translate_x() == pytest.approx(5, abs=1e-10)
+    assert resolver.translate_y() == pytest.approx(-3, abs=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# PRNG resolution
+# ---------------------------------------------------------------------------
+
+
+def test_deterministic() -> None:
+    full = _full_options()
+    a = _make_resolver(_minimal_style(), full)
+    b = _make_resolver(_minimal_style(), full)
+    assert a.flip() == b.flip()
+    assert a.font_family() == b.font_family()
+    assert a.font_weight() == b.font_weight()
+    assert a.scale() == b.scale()
+    assert a.border_radius() == b.border_radius()
+
+
+def test_different_seeds() -> None:
+    full = _full_options()
+    a = _make_resolver(_minimal_style(), {**full, "seed": "seed-a"})
+    b = _make_resolver(_minimal_style(), {**full, "seed": "seed-b"})
+    results = [
+        a.flip() != b.flip(),
+        a.font_family() != b.font_family(),
+        a.scale() != b.scale(),
+        a.rotate() != b.rotate(),
+    ]
+    assert any(results)
+
+
+def test_picks_from_arrays() -> None:
+    resolver = _make_resolver(
+        _minimal_style(),
+        {
+            "seed": "pick-test",
+            "flip": ["horizontal", "vertical"],
+            "skinColor": ["#f0c8a0", "#d4a574", "#8d5524"],
+        },
+    )
+    assert resolver.flip() in ["horizontal", "vertical"]
+    assert len(resolver.color("skin")) == 1
+    assert resolver.color("skin")[0] in ["#f0c8a0", "#d4a574", "#8d5524"]
+
+
+def test_interpolates_ranges() -> None:
+    resolver = _make_resolver(
+        _minimal_style(),
+        {
+            "seed": "range-test",
+            "scale": [0.8, 1.2],
+            "borderRadius": [0, 50],
+            "rotate": [-15, 15],
+            "translateX": [-5, 5],
+        },
+    )
+    assert 0.8 <= resolver.scale() <= 1.2
+    assert 0 <= resolver.border_radius() <= 50
+    assert -15 <= resolver.rotate() <= 15
+
+
+def test_picks_color_fill_from_arrays() -> None:
+    resolver = _make_resolver(
+        _minimal_style(),
+        {"seed": "fill-test", "skinColorFill": ["solid", "linear", "radial"]},
+    )
+    assert resolver.color_fill("skin") in ["solid", "linear", "radial"]
+
+
+def test_color_fill_stops_for_gradient() -> None:
+    resolver = _make_resolver(
+        _minimal_style(),
+        {
+            "seed": "gradient-test",
+            "skinColor": ["#f0c8a0", "#d4a574", "#8d5524"],
+            "skinColorFill": "linear",
+            "skinColorFillStops": 2,
+        },
+    )
+    colors = resolver.color("skin")
+    assert len(colors) == 2
+    for c in colors:
+        assert c in ["#f0c8a0", "#d4a574", "#8d5524"]
+
+
+def test_defaults_to_2_stops_for_gradient() -> None:
+    resolver = _make_resolver(
+        _minimal_style(),
+        {
+            "seed": "gradient-default-test",
+            "skinColor": ["#f0c8a0", "#d4a574", "#8d5524"],
+            "skinColorFill": "radial",
+        },
+    )
+    assert len(resolver.color("skin")) == 2
+
+
+def test_single_color_for_solid_fill() -> None:
+    resolver = _make_resolver(
+        _minimal_style(),
+        {
+            "seed": "solid-test",
+            "skinColor": ["#f0c8a0", "#d4a574", "#8d5524"],
+            "skinColorFill": "solid",
+        },
+    )
+    colors = resolver.color("skin")
+    assert len(colors) == 1
+    assert colors[0] in ["#f0c8a0", "#d4a574", "#8d5524"]
+
+
+def test_picks_from_font_weight_array() -> None:
+    resolver = _make_resolver(
+        _minimal_style(), {"seed": "fw-test", "fontWeight": [400, 700]}
+    )
+    assert resolver.font_weight() in [400, 700]
+
+
+# ---------------------------------------------------------------------------
+# colorFillStops via color()
+# ---------------------------------------------------------------------------
+
+
+def test_respects_custom_stops_count() -> None:
+    resolver = _make_resolver(
+        _minimal_style(),
+        {
+            "seed": "stops-test",
+            "skinColor": ["#ff0000", "#00ff00", "#0000ff", "#ffffff"],
+            "skinColorFill": "linear",
+            "skinColorFillStops": 3,
+        },
+    )
+    assert len(resolver.color("skin")) == 3
+
+
+def test_picks_integer_stops_from_range() -> None:
+    for i in range(20):
+        resolver = _make_resolver(
+            _minimal_style(),
+            {
+                "seed": f"stops-{i}",
+                "skinColor": ["#ff0000", "#00ff00", "#0000ff", "#ffffff", "#000000"],
+                "skinColorFill": "radial",
+                "skinColorFillStops": [2, 4],
+            },
+        )
+        count = len(resolver.color("skin"))
+        assert 2 <= count <= 4
+
+
+# ---------------------------------------------------------------------------
+# component_transform
+# ---------------------------------------------------------------------------
+
+
+def test_component_transform_identity_defaults() -> None:
+    t = _make_resolver(
+        _style_with_components(), {"seed": "identity"}
+    ).component_transform("eyes")
+    assert t["rotate"] == pytest.approx(0.0, abs=1e-10)
+    assert t["translateX"] == pytest.approx(0.0, abs=1e-10)
+    assert t["translateY"] == pytest.approx(0.0, abs=1e-10)
+    assert t["scale"] == pytest.approx(1.0, abs=1e-10)
+
+
+def test_component_transform_draws_rotate_from_definition() -> None:
+    style = Style(
+        {
+            "canvas": {"width": 100, "height": 100, "elements": []},
+            "components": {
+                "eyes": {
+                    "width": 50,
+                    "height": 50,
+                    "rotate": {"min": -10, "max": 10},
+                    "variants": {"open": {"elements": []}},
+                }
+            },
+        }
+    )
+    t = _make_resolver(style, {"seed": "rotate"}).component_transform("eyes")
+    assert -10 <= t["rotate"] <= 10
+
+
+def test_component_transform_is_deterministic_per_seed() -> None:
+    a = _make_resolver(_style_with_components(), {"seed": "pick"})
+    b = _make_resolver(_style_with_components(), {"seed": "pick"})
+    assert a.component_transform("eyes") == b.component_transform("eyes")
+
+
+def test_component_transform_identity_for_unknown_component() -> None:
+    t = _make_resolver(_minimal_style(), {"seed": "unknown"}).component_transform(
+        "missing"
+    )
+    assert t["rotate"] == pytest.approx(0.0, abs=1e-10)
+    assert t["translateX"] == pytest.approx(0.0, abs=1e-10)
+    assert t["translateY"] == pytest.approx(0.0, abs=1e-10)
+    assert t["scale"] == pytest.approx(1.0, abs=1e-10)
+
+
+def test_root_scale_defaults_to_one() -> None:
+    resolver = _make_resolver(_minimal_style(), {"seed": "root-scale"})
+    assert resolver.scale() == pytest.approx(1.0, abs=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# probability / visibility
+# ---------------------------------------------------------------------------
+
+
+def test_variant_when_probability_100() -> None:
+    resolver = _make_resolver(
+        _style_with_components(), {"seed": "visible-test", "eyesProbability": 100}
+    )
+    assert resolver.variant("eyes") is not None
+
+
+def test_variant_null_when_probability_0() -> None:
+    resolver = _make_resolver(
+        _style_with_components(), {"seed": "hidden-test", "eyesProbability": 0}
+    )
+    assert resolver.variant("eyes") is None
+
+
+def test_variant_visible_by_default() -> None:
+    resolver = _make_resolver(
+        _style_with_components(), {"seed": "default-visible-test"}
+    )
+    assert resolver.variant("eyes") is not None
+
+
+# ---------------------------------------------------------------------------
+# variant constraints
+# ---------------------------------------------------------------------------
+
+
+def test_only_picks_from_style_defined_variants() -> None:
+    resolver = _make_resolver(
+        _style_with_components(),
+        {"seed": "variant-test", "eyesVariant": ["open", "closed", "invalid"]},
+    )
+    result = resolver.variant("eyes")
+    assert result is not None
+    assert result in ["open", "closed", "wink"]
+    assert result != "invalid"
+
+
+def test_variant_null_when_no_user_variants_match() -> None:
+    resolver = _make_resolver(
+        _style_with_components(),
+        {"seed": "fallback-test", "eyesVariant": ["invalid1", "invalid2"]},
+    )
+    assert resolver.variant("eyes") is None
+
+
+def test_empty_variant_array_yields_null_variant() -> None:
+    resolver = _make_resolver(
+        _style_with_components(), {"seed": "empty-test", "eyesVariant": []}
+    )
+    assert resolver.variant("eyes") is None
+
+
+def test_picks_from_style_variants_when_no_option() -> None:
+    resolver = _make_resolver(_style_with_components(), {"seed": "default-test"})
+    result = resolver.variant("eyes")
+    assert result is not None
+    assert result in ["open", "closed", "wink"]
+
+
+def test_variant_null_when_component_missing() -> None:
+    resolver = _make_resolver(
+        _minimal_style(), {"seed": "no-component-test", "eyesVariant": "open"}
+    )
+    assert resolver.variant("eyes") is None
+
+
+# ---------------------------------------------------------------------------
+# color constraints
+# ---------------------------------------------------------------------------
+
+
+def test_contrast_to_sorting() -> None:
+    resolver = _make_resolver(
+        _style_with_colors(),
+        {
+            "seed": "contrast-test",
+            "skinColor": "#f0c8a0",
+            "backgroundColor": ["#ffffff", "#000000", "#cccccc"],
+        },
+    )
+    colors = resolver.color("background")
+    assert len(colors) == 1
+    assert colors[0] == "#000000"
+
+
+def test_not_equal_to_filtering() -> None:
+    resolver = _make_resolver(
+        _style_with_colors(),
+        {
+            "seed": "not-equal-test",
+            "skinColor": "#f0c8a0",
+            "hairColor": ["#f0c8a0", "#2c1b18", "#b55239"],
+        },
+    )
+    colors = resolver.color("hair")
+    assert len(colors) == 1
+    assert colors[0] != "#f0c8a0"
+
+
+def test_not_equal_to_keeps_all_when_all_would_be_filtered() -> None:
+    resolver = _make_resolver(
+        _style_with_colors(),
+        {"seed": "all-filtered-test", "skinColor": "#f0c8a0", "hairColor": ["#f0c8a0"]},
+    )
+    colors = resolver.color("hair")
+    assert len(colors) == 1
+    assert colors[0] == "#f0c8a0"
+
+
+def test_color_caching() -> None:
+    resolver = _make_resolver(
+        _style_with_colors(),
+        {"seed": "cache-test", "skinColor": ["#f0c8a0", "#d4a574"]},
+    )
+    assert resolver.color("skin") is resolver.color("skin")
+
+
+def test_color_without_style_definition() -> None:
+    resolver = _make_resolver(
+        _minimal_style(),
+        {"seed": "no-style-test", "customColor": ["#ff0000", "#00ff00"]},
+    )
+    colors = resolver.color("custom")
+    assert len(colors) == 1
+    assert colors[0] in ["#ff0000", "#00ff00"]
+
+
+def test_circular_contrast_to_throws() -> None:
+    style = Style(
+        {
+            "canvas": {"width": 100, "height": 100, "elements": []},
+            "colors": {
+                "a": {"values": ["#ff0000", "#00ff00"], "contrastTo": "b"},
+                "b": {"values": ["#0000ff", "#ffffff"], "contrastTo": "a"},
+            },
+        }
+    )
+    resolver = _make_resolver(
+        style,
+        {
+            "seed": "circular-test",
+            "aColor": ["#ff0000", "#00ff00"],
+            "bColor": ["#0000ff", "#ffffff"],
+        },
+    )
+    with pytest.raises(CircularColorReferenceError) as exc_info:
+        resolver.color("a")
+    assert exc_info.value.chain == ["a", "b", "a"]
+    assert "a → b → a" in str(exc_info.value)
+
+
+def test_circular_not_equal_to_throws() -> None:
+    style = Style(
+        {
+            "canvas": {"width": 100, "height": 100, "elements": []},
+            "colors": {
+                "a": {"values": ["#ff0000"], "notEqualTo": ["b"]},
+                "b": {"values": ["#00ff00"], "notEqualTo": ["a"]},
+            },
+        }
+    )
+    resolver = _make_resolver(
+        style,
+        {
+            "seed": "circular-not-equal-test",
+            "aColor": ["#ff0000"],
+            "bColor": ["#00ff00"],
+        },
+    )
+    with pytest.raises(CircularColorReferenceError) as exc_info:
+        resolver.color("a")
+    assert exc_info.value.chain == ["a", "b", "a"]
+    assert "a → b → a" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# resolved
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_includes_consumed_values() -> None:
+    resolver = _make_resolver(
+        _minimal_style(),
+        {"seed": "test", "flip": ["horizontal", "vertical"], "scale": [0.5, 1]},
+    )
+    resolver.seed()
+    resolver.flip()
+    resolver.scale()
+    resolved = resolver.resolved()
+    assert resolved["flip"] in ["horizontal", "vertical", "none"]
+    assert isinstance(resolved["scale"], (int, float))
+
+
+def test_resolved_does_not_include_seed() -> None:
+    resolver = _make_resolver(_minimal_style(), {"seed": "test"})
+    resolver.seed()
+    assert "seed" not in resolver.resolved()
+
+
+def test_resolved_memoized() -> None:
+    resolver = _make_resolver(
+        _minimal_style(), {"seed": "test", "flip": ["horizontal", "vertical"]}
+    )
+    assert resolver.flip() == resolver.flip()
+
+
+def test_resolved_includes_variant_values() -> None:
+    resolver = _make_resolver(
+        _style_with_components(), {"seed": "test", "eyesVariant": ["open", "closed"]}
+    )
+    resolver.variant("eyes")
+    resolved = resolver.resolved()
+    assert "eyesVariant" in resolved
+    assert resolved["eyesVariant"] in ["open", "closed", "wink"]
+
+
+def test_resolved_includes_color_values() -> None:
+    resolver = _make_resolver(
+        _style_with_colors(), {"seed": "test", "skinColor": ["#ff0000", "#00ff00"]}
+    )
+    resolver.color("skin")
+    resolved = resolver.resolved()
+    assert "skinColor" in resolved
+    assert isinstance(resolved["skinColor"], list)
+
+
+# ---------------------------------------------------------------------------
+# variant weights
+# ---------------------------------------------------------------------------
+
+
+def test_weight_zero_never_picked() -> None:
+    for i in range(100):
+        resolver = _make_resolver(_style_with_weights(), {"seed": f"weight-{i}"})
+        assert resolver.variant("eyes") != "hidden"
+
+
+def test_weight_zero_allowed_when_explicit() -> None:
+    resolver = _make_resolver(
+        _style_with_weights(), {"seed": "explicit-hidden", "eyesVariant": "hidden"}
+    )
+    assert resolver.variant("eyes") == "hidden"
+
+
+def test_higher_weight_favored() -> None:
+    common_count = sum(
+        1
+        for i in range(200)
+        if _make_resolver(_style_with_weights(), {"seed": f"favor-{i}"}).variant("eyes")
+        == "common"
+    )
+    assert common_count > 100
+
+
+def test_object_variant_overrides_weights() -> None:
+    for i in range(100):
+        resolver = _make_resolver(
+            _style_with_weights(),
+            {"seed": f"override-{i}", "eyesVariant": {"hidden": 1}},
+        )
+        assert resolver.variant("eyes") == "hidden"
+
+
+def test_object_variant_filters_and_weights() -> None:
+    for i in range(100):
+        resolver = _make_resolver(
+            _style_with_weights(),
+            {"seed": f"filter-{i}", "eyesVariant": {"common": 1, "rare": 1}},
+        )
+        assert resolver.variant("eyes") in ["common", "rare"]
+
+
+def test_all_weights_zero_fallback() -> None:
+    style = Style(
+        {
+            "canvas": {"width": 100, "height": 100, "elements": []},
+            "components": {
+                "eyes": {
+                    "width": 50,
+                    "height": 50,
+                    "variants": {
+                        "a": {"elements": [], "weight": 0},
+                        "b": {"elements": [], "weight": 0},
+                    },
+                }
+            },
+        }
+    )
+    resolver = _make_resolver(style, {"seed": "all-zero"})
+    assert resolver.variant("eyes") in ["a", "b"]
+
+
+def test_deterministic_with_weights() -> None:
+    a = _make_resolver(_style_with_weights(), {"seed": "deterministic-test"})
+    b = _make_resolver(_style_with_weights(), {"seed": "deterministic-test"})
+    assert a.variant("eyes") == b.variant("eyes")
+
+
+# ---------------------------------------------------------------------------
+# color_angle
+# ---------------------------------------------------------------------------
+
+
+def test_color_angle_default() -> None:
+    resolver = _make_resolver(_minimal_style(), {})
+    assert resolver.color_angle("skin") == pytest.approx(0, abs=1e-10)
+
+
+def test_color_angle_single_value() -> None:
+    resolver = _make_resolver(_minimal_style(), {"skinColorAngle": 45})
+    assert resolver.color_angle("skin") == pytest.approx(45, abs=1e-10)
+
+
+def test_color_angle_range() -> None:
+    resolver = _make_resolver(
+        _minimal_style(), {"seed": "angle-test", "skinColorAngle": [-90, 90]}
+    )
+    value = resolver.color_angle("skin")
+    assert -90 <= value <= 90

--- a/src/python/core/tests/test_style.py
+++ b/src/python/core/tests/test_style.py
@@ -1,0 +1,398 @@
+"""Tests for the Style wrapper and its value-object views."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from dicebear import Style
+from dicebear.errors import StyleValidationError, ValidationError
+
+
+def _minimal() -> dict[str, Any]:
+    return {"canvas": {"width": 100, "height": 100, "elements": []}}
+
+
+def _full() -> dict[str, Any]:
+    return {
+        "$schema": "https://example.com/schema.json",
+        "$comment": "Test style",
+        "meta": {
+            "license": {
+                "name": "MIT",
+                "url": "https://example.com/license",
+                "text": "MIT License",
+            },
+            "creator": {"name": "Test", "url": "https://example.com"},
+            "source": {"name": "Source", "url": "https://example.com/source"},
+        },
+        "canvas": {
+            "width": 200,
+            "height": 200,
+            "elements": [
+                {
+                    "type": "element",
+                    "name": "rect",
+                    "attributes": {"width": "100", "height": "100", "fill": "#ff0000"},
+                    "children": [{"type": "text", "value": "hello"}],
+                },
+                {"type": "component", "name": "eyes"},
+                {"type": "text", "value": {"type": "variable", "name": "initials"}},
+            ],
+        },
+        "components": {
+            "eyes": {
+                "width": 50,
+                "height": 50,
+                "probability": 100,
+                "rotate": {"min": -10, "max": 10},
+                "translate": {"x": {"min": 0, "max": 5}, "y": {"min": -2, "max": 2}},
+                "variants": {
+                    "open": {
+                        "elements": [
+                            {
+                                "type": "element",
+                                "name": "circle",
+                                "attributes": {"r": "10", "cx": "25", "cy": "25"},
+                            }
+                        ]
+                    },
+                    "closed": {
+                        "elements": [
+                            {
+                                "type": "element",
+                                "name": "line",
+                                "attributes": {
+                                    "x1": "10",
+                                    "y1": "25",
+                                    "x2": "40",
+                                    "y2": "25",
+                                },
+                            }
+                        ]
+                    },
+                },
+            }
+        },
+        "colors": {
+            "skin": {"values": ["#f0c8a0", "#d4a574", "#8d5524"]},
+            "hair": {"values": ["#2c1b18", "#b55239"], "notEqualTo": ["skin"]},
+            "background": {"values": ["#ffffff", "#000000"], "contrastTo": "skin"},
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# constructor
+# ---------------------------------------------------------------------------
+
+
+def test_accepts_minimal_definition() -> None:
+    assert Style(_minimal()) is not None
+
+
+def test_accepts_full_definition() -> None:
+    assert Style(_full()) is not None
+
+
+def test_throws_style_validation_error_for_invalid_data() -> None:
+    with pytest.raises(StyleValidationError):
+        Style({})
+
+
+def test_throws_validation_error() -> None:
+    with pytest.raises(ValidationError):
+        Style({})
+
+
+def test_throws_runtime_error() -> None:
+    with pytest.raises(RuntimeError):
+        Style({})
+
+
+def test_error_includes_details() -> None:
+    with pytest.raises(StyleValidationError) as exc_info:
+        Style({})
+    assert isinstance(exc_info.value.details, list)
+    assert len(exc_info.value.details) > 0
+
+
+# ---------------------------------------------------------------------------
+# primitive methods
+# ---------------------------------------------------------------------------
+
+
+def test_returns_schema() -> None:
+    full = _full()
+    assert Style(full).schema() == full["$schema"]
+
+
+def test_returns_comment() -> None:
+    full = _full()
+    assert Style(full).comment() == full["$comment"]
+
+
+def test_returns_none_for_missing_optional_primitives() -> None:
+    style = Style(_minimal())
+    assert style.schema() is None
+    assert style.comment() is None
+
+
+def test_returns_defaults_for_missing_optional_objects() -> None:
+    style = Style(_minimal())
+    assert style.meta() is not None
+    assert style.meta().license().name() is None
+    assert style.meta().creator().name() is None
+    assert style.meta().source().name() is None
+    assert style.attributes() == {}
+
+
+# ---------------------------------------------------------------------------
+# canvas
+# ---------------------------------------------------------------------------
+
+
+def test_canvas_width_and_height() -> None:
+    style = Style(_full())
+    assert style.canvas().width() == 200
+    assert style.canvas().height() == 200
+
+
+def test_canvas_elements() -> None:
+    style = Style(_full())
+    elements = style.canvas().elements()
+    assert len(elements) == 3
+    assert elements[0].type() == "element"
+    assert elements[0].name() == "rect"
+    assert elements[1].type() == "component"
+    assert elements[1].name() == "eyes"
+
+
+def test_canvas_element_children() -> None:
+    children = Style(_full()).canvas().elements()[0].children()
+    assert len(children) == 1
+    assert children[0].type() == "text"
+    assert children[0].value() == "hello"
+
+
+def test_canvas_element_attributes() -> None:
+    attrs = Style(_full()).canvas().elements()[0].attributes()
+    assert attrs is not None
+    assert attrs["width"] == "100"
+    assert attrs["fill"] == "#ff0000"
+
+
+def test_canvas_element_variable_reference() -> None:
+    el = Style(_full()).canvas().elements()[2]
+    assert el.type() == "text"
+    assert el.value() == {"type": "variable", "name": "initials"}
+
+
+def test_canvas_caches_elements() -> None:
+    style = Style(_full())
+    assert style.canvas().elements() is style.canvas().elements()
+
+
+# ---------------------------------------------------------------------------
+# meta
+# ---------------------------------------------------------------------------
+
+
+def test_meta_license() -> None:
+    meta = Style(_full()).meta()
+    assert meta.license().name() == "MIT"
+    assert meta.license().url() == "https://example.com/license"
+    assert meta.license().text() == "MIT License"
+
+
+def test_meta_creator() -> None:
+    meta = Style(_full()).meta()
+    assert meta.creator().name() == "Test"
+    assert meta.creator().url() == "https://example.com"
+
+
+def test_meta_source() -> None:
+    assert Style(_full()).meta().source().name() == "Source"
+
+
+def test_meta_cached() -> None:
+    style = Style(_full())
+    assert style.meta() is style.meta()
+
+
+# ---------------------------------------------------------------------------
+# components
+# ---------------------------------------------------------------------------
+
+
+def test_components_returns_map() -> None:
+    components = Style(_full()).components()
+    assert len(components) == 1
+    assert "eyes" in components
+
+
+def test_component_properties() -> None:
+    eyes = Style(_full()).components()["eyes"]
+    assert eyes.width() == 50
+    assert eyes.height() == 50
+    assert eyes.probability() == 100
+    assert eyes.rotate() == {"min": -10, "max": 10}
+
+
+def test_component_translate() -> None:
+    translate = Style(_full()).components()["eyes"].translate()
+    assert translate.x() == {"min": 0, "max": 5}
+    assert translate.y() == {"min": -2, "max": 2}
+
+
+def test_component_variants() -> None:
+    eyes = Style(_full()).components()["eyes"]
+    assert len(eyes.variants()) == 2
+    assert "open" in eyes.variants()
+    assert "closed" in eyes.variants()
+
+
+def test_variant_elements() -> None:
+    open_ = Style(_full()).components()["eyes"].variants()["open"]
+    assert len(open_.elements()) == 1
+    assert open_.elements()[0].name() == "circle"
+
+
+def test_empty_components_when_none() -> None:
+    assert len(Style(_minimal()).components()) == 0
+
+
+def test_components_cached() -> None:
+    style = Style(_full())
+    assert style.components() is style.components()
+
+
+# ---------------------------------------------------------------------------
+# colors
+# ---------------------------------------------------------------------------
+
+
+def test_colors_returns_map() -> None:
+    assert len(Style(_full()).colors()) == 3
+
+
+def test_color_values() -> None:
+    skin = Style(_full()).colors()["skin"]
+    assert skin.values() == ["#f0c8a0", "#d4a574", "#8d5524"]
+
+
+def test_color_not_equal_to() -> None:
+    hair = Style(_full()).colors()["hair"]
+    assert hair.not_equal_to() == ["skin"]
+
+
+def test_color_contrast_to() -> None:
+    background = Style(_full()).colors()["background"]
+    assert background.contrast_to() == "skin"
+
+
+def test_empty_colors_when_none() -> None:
+    assert len(Style(_minimal()).colors()) == 0
+
+
+def test_colors_cached() -> None:
+    style = Style(_full())
+    assert style.colors() is style.colors()
+
+
+# ---------------------------------------------------------------------------
+# component aliases
+# ---------------------------------------------------------------------------
+
+
+def _alias_definition() -> dict[str, Any]:
+    return {
+        "canvas": {"width": 100, "height": 100, "elements": []},
+        "components": {
+            "eyes": {
+                "width": 50,
+                "height": 60,
+                "probability": 80,
+                "rotate": {"min": -10, "max": 10},
+                "scale": {"min": 0.9, "max": 1.1},
+                "translate": {"x": {"min": -5, "max": 5}, "y": {"min": -2, "max": 2}},
+                "variants": {
+                    "open": {
+                        "elements": [
+                            {
+                                "type": "element",
+                                "name": "circle",
+                                "attributes": {"r": "5"},
+                            }
+                        ]
+                    },
+                    "closed": {
+                        "elements": [
+                            {
+                                "type": "element",
+                                "name": "line",
+                                "attributes": {"x1": "0", "x2": "10"},
+                            }
+                        ]
+                    },
+                },
+            },
+            "eyesRight": {"extends": "eyes"},
+        },
+    }
+
+
+def test_alias_exposed_as_map_entry() -> None:
+    components = Style(_alias_definition()).components()
+    assert "eyesRight" in components
+    assert components["eyesRight"].extends_name() == "eyes"
+    assert components["eyes"].extends_name() is None
+
+
+def test_alias_inherits_width_and_height() -> None:
+    alias = Style(_alias_definition()).components()["eyesRight"]
+    assert alias.width() == 50
+    assert alias.height() == 60
+
+
+def test_alias_inherits_variants() -> None:
+    alias = Style(_alias_definition()).components()["eyesRight"]
+    assert list(alias.variants().keys()) == ["open", "closed"]
+
+
+def test_alias_delegates_probability_rotate_scale_translate_to_source() -> None:
+    alias = Style(_alias_definition()).components()["eyesRight"]
+    assert alias.probability() == 80
+    assert alias.rotate() == {"min": -10, "max": 10}
+    assert alias.scale() == {"min": 0.9, "max": 1.1}
+    assert alias.translate().x() == {"min": -5, "max": 5}
+    assert alias.translate().y() == {"min": -2, "max": 2}
+
+
+def test_alias_rejects_unknown_extends_target() -> None:
+    with pytest.raises(StyleValidationError):
+        Style(
+            {
+                "canvas": {"width": 100, "height": 100, "elements": []},
+                "components": {"eyesRight": {"extends": "missing"}},
+            }
+        )
+
+
+def test_alias_rejects_alias_of_alias() -> None:
+    with pytest.raises(StyleValidationError):
+        Style(
+            {
+                "canvas": {"width": 100, "height": 100, "elements": []},
+                "components": {
+                    "eyes": {
+                        "width": 10,
+                        "height": 10,
+                        "variants": {"open": {"elements": []}},
+                    },
+                    "eyesRight": {"extends": "eyes"},
+                    "eyesRightAgain": {"extends": "eyesRight"},
+                },
+            }
+        )

--- a/src/python/core/tests/utils/test_color.py
+++ b/src/python/core/tests/utils/test_color.py
@@ -1,0 +1,139 @@
+"""Tests for the color utility helpers."""
+
+from __future__ import annotations
+
+from dicebear.utils.color import Color
+
+# ---------------------------------------------------------------------------
+# to_rgb_hex
+# ---------------------------------------------------------------------------
+
+
+def test_to_rgb_hex_normalizes_6_digit() -> None:
+    assert Color.to_rgb_hex("#ff0000") == "#ff0000"
+
+
+def test_to_rgb_hex_normalizes_3_digit() -> None:
+    assert Color.to_rgb_hex("#f00") == "#ff0000"
+
+
+def test_to_rgb_hex_strips_alpha_4_digit() -> None:
+    assert Color.to_rgb_hex("#f008") == "#ff0000"
+
+
+def test_to_rgb_hex_strips_alpha_8_digit() -> None:
+    assert Color.to_rgb_hex("#ff000080") == "#ff0000"
+
+
+def test_to_rgb_hex_lowercases() -> None:
+    assert Color.to_rgb_hex("#FF0000") == "#ff0000"
+    assert Color.to_rgb_hex("#F00") == "#ff0000"
+
+
+def test_to_rgb_hex_handles_missing_prefix() -> None:
+    assert Color.to_rgb_hex("ff0000") == "#ff0000"
+    assert Color.to_rgb_hex("f00") == "#ff0000"
+
+
+# ---------------------------------------------------------------------------
+# parse_hex
+# ---------------------------------------------------------------------------
+
+
+def test_parse_hex_6_digit() -> None:
+    assert Color.parse_hex("#ff0000") == (255, 0, 0)
+    assert Color.parse_hex("#00ff00") == (0, 255, 0)
+    assert Color.parse_hex("#0000ff") == (0, 0, 255)
+
+
+def test_parse_hex_3_digit() -> None:
+    assert Color.parse_hex("#f00") == (255, 0, 0)
+    assert Color.parse_hex("#fff") == (255, 255, 255)
+
+
+def test_parse_hex_4_digit() -> None:
+    assert Color.parse_hex("#f008") == (255, 0, 0)
+
+
+def test_parse_hex_8_digit() -> None:
+    assert Color.parse_hex("#ff000080") == (255, 0, 0)
+
+
+def test_parse_hex_case_insensitive() -> None:
+    assert Color.parse_hex("#FF0000") == (255, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# luminance
+# ---------------------------------------------------------------------------
+
+
+def test_luminance_black_is_zero() -> None:
+    assert Color.luminance("#000000") == 0.0
+
+
+def test_luminance_white_is_one() -> None:
+    assert Color.luminance("#ffffff") == 1.0
+
+
+def test_luminance_mid_gray() -> None:
+    lum = Color.luminance("#808080")
+    assert 0.2 < lum < 0.25
+
+
+def test_luminance_3_digit_hex() -> None:
+    assert Color.luminance("#000") == 0.0
+    assert Color.luminance("#fff") == 1.0
+
+
+# ---------------------------------------------------------------------------
+# sort_by_contrast
+# ---------------------------------------------------------------------------
+
+
+def test_sort_by_contrast_descending() -> None:
+    result = Color.sort_by_contrast(["#ffffff", "#808080", "#000000"], "#ffffff")
+    assert result[0] == "#000000"
+    assert result[2] == "#ffffff"
+
+
+def test_sort_by_contrast_colored_reference() -> None:
+    result = Color.sort_by_contrast(["#000000", "#ffffff"], "#f0c8a0")
+    assert result[0] == "#000000"
+
+
+def test_sort_by_contrast_preserves_length() -> None:
+    result = Color.sort_by_contrast(["#ff0000", "#00ff00", "#0000ff"], "#ffffff")
+    assert len(result) == 3
+
+
+# ---------------------------------------------------------------------------
+# filter_not_equal_to
+# ---------------------------------------------------------------------------
+
+
+def test_filter_exact_matches() -> None:
+    result = Color.filter_not_equal_to(["#ff0000", "#00ff00", "#0000ff"], ["#ff0000"])
+    assert result == ["#00ff00", "#0000ff"]
+
+
+def test_filter_case_insensitive() -> None:
+    result = Color.filter_not_equal_to(["#ff0000", "#00ff00"], ["#FF0000"])
+    assert result == ["#00ff00"]
+
+
+def test_filter_matches_short_and_long_hex() -> None:
+    result = Color.filter_not_equal_to(["#ff0000", "#00ff00"], ["#f00"])
+    assert result == ["#00ff00"]
+
+
+def test_filter_keeps_all_when_would_empty() -> None:
+    result = Color.filter_not_equal_to(["#ff0000"], ["#ff0000"])
+    assert result == ["#ff0000"]
+
+
+def test_filter_multiple_exclusions() -> None:
+    result = Color.filter_not_equal_to(
+        ["#ff0000", "#00ff00", "#0000ff"], ["#ff0000", "#0000ff"]
+    )
+    assert result == ["#00ff00"]


### PR DESCRIPTION
Add a Python implementation of @dicebear/core under src/python/core, published as dicebear-core (import dicebear). It is a faithful translation of the PHP port and produces byte-identical SVG output to the JavaScript and PHP references, verified against the shared cross-language parity fixtures in tests/fixtures/parity (Fnv1a, Mulberry32, PRNG selection methods, number formatting, initials, and full Avatar rendering for the glass/initials/notionists/shape-grid/thumbs styles).

The package targets Python 3.10-3.14, depends on dicebear-schema (schemas read at runtime via importlib.resources, not vendored) and jsonschema, ships type information (py.typed, mypy strict), and is linted with ruff.

Also wires the port into the monorepo: a test-python CI job (ruff + mypy + pytest across 3.10-3.14), a publish-python job that builds and uploads dicebear-core to PyPI via trusted publishing on a release tag (like the npm packages, no token and no separate repository), and a pyproject version bump in scripts/version.mjs. CONTRIBUTING.md documents the port and release flow.